### PR TITLE
Use epoch for the heartbeat

### DIFF
--- a/workflow_db/database/db/migrate/20190612183248_use_epoch.rb
+++ b/workflow_db/database/db/migrate/20190612183248_use_epoch.rb
@@ -1,0 +1,6 @@
+class UseEpoch < ActiveRecord::Migration
+  def change
+    add_column :workflow_attempts, :last_heartbeat_epoch, :integer, limit: 8
+    add_column :background_workflow_executor_infos, :last_heartbeat_epoch, :integer, limit: 8
+  end
+end

--- a/workflow_db/database/db/schema.rb
+++ b/workflow_db/database/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190610183430) do
+ActiveRecord::Schema.define(version: 20190612183248) do
 
   create_table "application_configured_notifications", force: :cascade do |t|
     t.integer "application_id",             limit: 8, null: false
@@ -61,9 +61,10 @@ ActiveRecord::Schema.define(version: 20190610183430) do
   add_index "background_step_attempt_infos", ["step_attempt_id"], name: "index_background_step_attempt_infos_on_step_attempt_id", unique: true, using: :btree
 
   create_table "background_workflow_executor_infos", force: :cascade do |t|
-    t.string   "host",           limit: 255, null: false
-    t.integer  "status",         limit: 4,   null: false
-    t.datetime "last_heartbeat",             null: false
+    t.string   "host",                 limit: 255, null: false
+    t.integer  "status",               limit: 4,   null: false
+    t.datetime "last_heartbeat",                   null: false
+    t.integer  "last_heartbeat_epoch", limit: 8
   end
 
   add_index "background_workflow_executor_infos", ["host"], name: "index_background_workflow_executor_infos_on_host", using: :btree
@@ -273,6 +274,7 @@ ActiveRecord::Schema.define(version: 20190610183430) do
     t.string   "scm_remote",            limit: 255
     t.string   "commit_revision",       limit: 255
     t.string   "description",           limit: 255
+    t.integer  "last_heartbeat_epoch",  limit: 8
   end
 
   add_index "workflow_attempts", ["end_time"], name: "index_workflow_attempts_on_end_time", using: :btree

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IBackgroundWorkflowExecutorInfoPersistence.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IBackgroundWorkflowExecutorInfoPersistence.java
@@ -17,12 +17,14 @@ import java.util.List;
 import com.rapleaf.jack.IModelPersistence;
 
 public interface IBackgroundWorkflowExecutorInfoPersistence extends IModelPersistence<BackgroundWorkflowExecutorInfo> {
+  BackgroundWorkflowExecutorInfo create(final String host, final int status, final long last_heartbeat, final Long last_heartbeat_epoch) throws IOException;
   BackgroundWorkflowExecutorInfo create(final String host, final int status, final long last_heartbeat) throws IOException;
 
   BackgroundWorkflowExecutorInfo createDefaultInstance() throws IOException;
   List<BackgroundWorkflowExecutorInfo> findByHost(String value)  throws IOException;
   List<BackgroundWorkflowExecutorInfo> findByStatus(int value)  throws IOException;
   List<BackgroundWorkflowExecutorInfo> findByLastHeartbeat(long value)  throws IOException;
+  List<BackgroundWorkflowExecutorInfo> findByLastHeartbeatEpoch(Long value)  throws IOException;
 
   BackgroundWorkflowExecutorInfoQueryBuilder query();
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IWorkflowAttemptPersistence.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IWorkflowAttemptPersistence.java
@@ -17,7 +17,7 @@ import java.util.List;
 import com.rapleaf.jack.IModelPersistence;
 
 public interface IWorkflowAttemptPersistence extends IModelPersistence<WorkflowAttempt> {
-  WorkflowAttempt create(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) throws IOException;
+  WorkflowAttempt create(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) throws IOException;
   WorkflowAttempt create(final int workflow_execution_id, final String system_user, final String priority, final String pool, final String host) throws IOException;
 
   WorkflowAttempt createDefaultInstance() throws IOException;
@@ -38,6 +38,7 @@ public interface IWorkflowAttemptPersistence extends IModelPersistence<WorkflowA
   List<WorkflowAttempt> findByScmRemote(String value)  throws IOException;
   List<WorkflowAttempt> findByCommitRevision(String value)  throws IOException;
   List<WorkflowAttempt> findByDescription(String value)  throws IOException;
+  List<WorkflowAttempt> findByLastHeartbeatEpoch(Long value)  throws IOException;
 
   WorkflowAttemptQueryBuilder query();
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseWorkflowAttemptPersistenceImpl.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseWorkflowAttemptPersistenceImpl.java
@@ -37,7 +37,7 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
   private final IDatabases databases;
 
   public BaseWorkflowAttemptPersistenceImpl(BaseDatabaseConnection conn, IDatabases databases) {
-    super(conn, "workflow_attempts", Arrays.<String>asList("workflow_execution_id", "system_user", "shutdown_reason", "priority", "pool", "host", "start_time", "end_time", "status", "last_heartbeat", "launch_dir", "launch_jar", "error_email", "info_email", "scm_remote", "commit_revision", "description"));
+    super(conn, "workflow_attempts", Arrays.<String>asList("workflow_execution_id", "system_user", "shutdown_reason", "priority", "pool", "host", "start_time", "end_time", "status", "last_heartbeat", "launch_dir", "launch_jar", "error_email", "info_email", "scm_remote", "commit_revision", "description", "last_heartbeat_epoch"));
     this.databases = databases;
   }
 
@@ -60,10 +60,11 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
     String scm_remote = (String) fieldsMap.get(WorkflowAttempt._Fields.scm_remote);
     String commit_revision = (String) fieldsMap.get(WorkflowAttempt._Fields.commit_revision);
     String description = (String) fieldsMap.get(WorkflowAttempt._Fields.description);
-    return create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    Long last_heartbeat_epoch = (Long) fieldsMap.get(WorkflowAttempt._Fields.last_heartbeat_epoch);
+    return create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
   }
 
-  public WorkflowAttempt create(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) throws IOException {
+  public WorkflowAttempt create(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) throws IOException {
     StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
@@ -162,6 +163,12 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
           int fieldIndex16 = index++;
           statementSetters.add(stmt -> stmt.setString(fieldIndex16, description));
         }
+
+        if (last_heartbeat_epoch != null) {
+          nonNullFields.add("last_heartbeat_epoch");
+          int fieldIndex17 = index++;
+          statementSetters.add(stmt -> stmt.setLong(fieldIndex17, last_heartbeat_epoch));
+        }
       }
 
       @Override
@@ -178,7 +185,7 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
     };
 
     long __id = realCreate(statementCreator);
-    WorkflowAttempt newInst = new WorkflowAttempt(__id, workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, databases);
+    WorkflowAttempt newInst = new WorkflowAttempt(__id, workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
@@ -228,7 +235,7 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
     };
 
     long __id = realCreate(statementCreator);
-    WorkflowAttempt newInst = new WorkflowAttempt(__id, workflow_execution_id, system_user, null, priority, pool, host, null, null, null, null, null, null, null, null, null, null, null, databases);
+    WorkflowAttempt newInst = new WorkflowAttempt(__id, workflow_execution_id, system_user, null, priority, pool, host, null, null, null, null, null, null, null, null, null, null, null, null, databases);
     newInst.setCreated(true);
     cachedById.put(__id, newInst);
     clearForeignKeyCache();
@@ -336,6 +343,9 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
             case description:
               preparedStatement.setString(i+1, (String) nonNullValues.get(i));
               break;
+            case last_heartbeat_epoch:
+              preparedStatement.setLong(i+1, (Long) nonNullValues.get(i));
+              break;
           }
         } catch (SQLException e) {
           throw new IOException(e);
@@ -419,6 +429,9 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
                 break;
               case description:
                 preparedStatement.setString(++index, (String) parameter);
+                break;
+              case last_heartbeat_epoch:
+                preparedStatement.setLong(++index, (Long) parameter);
                 break;
             }
           }
@@ -507,6 +520,11 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
     } else if (model.getDescription() != null) {
       stmt.setString(index++, model.getDescription());
     }
+    if (setNull && model.getLastHeartbeatEpoch() == null) {
+      stmt.setNull(index++, java.sql.Types.INTEGER);
+    } else if (model.getLastHeartbeatEpoch() != null) {
+      stmt.setLong(index++, model.getLastHeartbeatEpoch());
+    }
     stmt.setLong(index, model.getId());
   }
 
@@ -532,6 +550,7 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
       allFields || selectedFields.contains(WorkflowAttempt._Fields.scm_remote) ? rs.getString("scm_remote") : null,
       allFields || selectedFields.contains(WorkflowAttempt._Fields.commit_revision) ? rs.getString("commit_revision") : null,
       allFields || selectedFields.contains(WorkflowAttempt._Fields.description) ? rs.getString("description") : null,
+      allFields || selectedFields.contains(WorkflowAttempt._Fields.last_heartbeat_epoch) ? getLongOrNull(rs, "last_heartbeat_epoch") : null,
       databases
     );
   }
@@ -602,6 +621,10 @@ public class BaseWorkflowAttemptPersistenceImpl extends AbstractDatabaseModel<Wo
 
   public List<WorkflowAttempt> findByDescription(final String value) throws IOException {
     return find(Collections.<Enum, Object>singletonMap(WorkflowAttempt._Fields.description, value));
+  }
+
+  public List<WorkflowAttempt> findByLastHeartbeatEpoch(final Long value) throws IOException {
+    return find(Collections.<Enum, Object>singletonMap(WorkflowAttempt._Fields.last_heartbeat_epoch, value));
   }
 
   public WorkflowAttemptQueryBuilder query() {

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/migration-version.txt
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/migration-version.txt
@@ -1,1 +1,1 @@
-Models Generated With Migration: 20190204201620
+Models Generated With Migration: 20190612183248

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/BackgroundAttemptInfo.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/BackgroundAttemptInfo.java
@@ -326,9 +326,9 @@ public class BackgroundAttemptInfo extends ModelWithId<BackgroundAttemptInfo, ID
     return newWorkflowAttempt;
   }
 
-  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) throws IOException {
+  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) throws IOException {
  
-    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
     setWorkflowAttemptId(newWorkflowAttempt.getId());
     save();
     __assoc_workflow_attempt.clearCache();

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/BackgroundStepAttemptInfo.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/BackgroundStepAttemptInfo.java
@@ -473,6 +473,15 @@ public class BackgroundStepAttemptInfo extends ModelWithId<BackgroundStepAttempt
     return newBackgroundWorkflowExecutorInfo;
   }
 
+  public BackgroundWorkflowExecutorInfo createBackgroundWorkflowExecutorInfo(final String host, final int status, final long last_heartbeat, final Long last_heartbeat_epoch) throws IOException {
+ 
+    BackgroundWorkflowExecutorInfo newBackgroundWorkflowExecutorInfo = databases.getWorkflowDb().backgroundWorkflowExecutorInfos().create(host, status, last_heartbeat, last_heartbeat_epoch);
+    setBackgroundWorkflowExecutorInfoId(JackUtility.safeLongToInt(newBackgroundWorkflowExecutorInfo.getId()));
+    save();
+    __assoc_background_workflow_executor_info.clearCache();
+    return newBackgroundWorkflowExecutorInfo;
+  }
+
   public BackgroundWorkflowExecutorInfo createBackgroundWorkflowExecutorInfo() throws IOException {
  
     BackgroundWorkflowExecutorInfo newBackgroundWorkflowExecutorInfo = databases.getWorkflowDb().backgroundWorkflowExecutorInfos().create("", 0, 0L);

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/BackgroundWorkflowExecutorInfo.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/BackgroundWorkflowExecutorInfo.java
@@ -34,13 +34,14 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkflowExecutorInfo, IDatabases> implements Comparable<BackgroundWorkflowExecutorInfo>{
   
-  public static final long serialVersionUID = -5307964431083157522L;
+  public static final long serialVersionUID = 6214690017522203866L;
 
   public static class Tbl extends AbstractTable<BackgroundWorkflowExecutorInfo.Attributes, BackgroundWorkflowExecutorInfo> {
     public final Column<Long> ID;
     public final Column<String> HOST;
     public final Column<Integer> STATUS;
     public final Column<Long> LAST_HEARTBEAT;
+    public final Column<Long> LAST_HEARTBEAT_EPOCH;
 
     private Tbl(String alias) {
       super("background_workflow_executor_infos", alias, BackgroundWorkflowExecutorInfo.Attributes.class, BackgroundWorkflowExecutorInfo.class);
@@ -48,7 +49,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       this.HOST = Column.fromField(alias, _Fields.host, String.class);
       this.STATUS = Column.fromField(alias, _Fields.status, Integer.class);
       this.LAST_HEARTBEAT = Column.fromTimestamp(alias, _Fields.last_heartbeat);
-      Collections.addAll(this.allColumns, ID, HOST, STATUS, LAST_HEARTBEAT);
+      this.LAST_HEARTBEAT_EPOCH = Column.fromField(alias, _Fields.last_heartbeat_epoch, Long.class);
+      Collections.addAll(this.allColumns, ID, HOST, STATUS, LAST_HEARTBEAT, LAST_HEARTBEAT_EPOCH);
     }
 
     public static Tbl as(String alias) {
@@ -61,6 +63,7 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
   public static final Column<String> HOST = TBL.HOST;
   public static final Column<Integer> STATUS = TBL.STATUS;
   public static final Column<Long> LAST_HEARTBEAT = TBL.LAST_HEARTBEAT;
+  public static final Column<Long> LAST_HEARTBEAT_EPOCH = TBL.LAST_HEARTBEAT_EPOCH;
 
   private final Attributes attributes;
 
@@ -73,6 +76,7 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
     host,
     status,
     last_heartbeat,
+    last_heartbeat_epoch,
   }
 
   @Override
@@ -83,6 +87,17 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
     return cachedTypedId;
   }
 
+  public BackgroundWorkflowExecutorInfo(long id, final String host, final int status, final long last_heartbeat, final Long last_heartbeat_epoch, IDatabases databases) {
+    super(databases);
+    attributes = new Attributes(id, host, status, last_heartbeat, last_heartbeat_epoch);
+    this.__assoc_background_step_attempt_info = new HasManyAssociation<>(databases.getWorkflowDb().backgroundStepAttemptInfos(), "background_workflow_executor_info_id", getId());
+  }
+
+  public BackgroundWorkflowExecutorInfo(long id, final String host, final int status, final long last_heartbeat, final Long last_heartbeat_epoch) {
+    super(null);
+    attributes = new Attributes(id, host, status, last_heartbeat, last_heartbeat_epoch);
+  }
+  
   public BackgroundWorkflowExecutorInfo(long id, final String host, final int status, final long last_heartbeat, IDatabases databases) {
     super(databases);
     attributes = new Attributes(id, host, status, last_heartbeat);
@@ -163,6 +178,16 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
     return this;
   }
 
+  public Long getLastHeartbeatEpoch() {
+    return attributes.getLastHeartbeatEpoch();
+  }
+
+  public BackgroundWorkflowExecutorInfo setLastHeartbeatEpoch(Long newval) {
+    attributes.setLastHeartbeatEpoch(newval);
+    cachedHashCode = 0;
+    return this;
+  }
+
   public void setField(_Fields field, Object value) {
     switch (field) {
       case host:
@@ -173,6 +198,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
         break;
       case last_heartbeat:
         setLastHeartbeat((Long)value);
+        break;
+      case last_heartbeat_epoch:
+        setLastHeartbeatEpoch((Long)value);
         break;
       default:
         throw new IllegalStateException("Invalid field: " + field);
@@ -192,6 +220,10 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       setLastHeartbeat((Long)  value);
       return;
     }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      setLastHeartbeatEpoch((Long)  value);
+      return;
+    }
     throw new IllegalStateException("Invalid field: " + fieldName);
   }
 
@@ -203,6 +235,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
         return int.class;
       case last_heartbeat:
         return long.class;
+      case last_heartbeat_epoch:
+        return Long.class;
       default:
         throw new IllegalStateException("Invalid field: " + field);
     }    
@@ -217,6 +251,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
     }
     if (fieldName.equals("last_heartbeat")) {
       return long.class;
+    }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      return Long.class;
     }
     throw new IllegalStateException("Invalid field name: " + fieldName);
   }
@@ -239,6 +276,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
     if (fieldName.equals("last_heartbeat")) {
       return getLastHeartbeat();
     }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      return getLastHeartbeatEpoch();
+    }
     throw new IllegalStateException("Invalid field name: " + fieldName);
   }
 
@@ -250,6 +290,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
         return getStatus();
       case last_heartbeat:
         return getLastHeartbeat();
+      case last_heartbeat_epoch:
+        return getLastHeartbeatEpoch();
     }
     throw new IllegalStateException("Invalid field: " + field);
   }
@@ -267,6 +309,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
     if (fieldName.equals("last_heartbeat")) {
       return true;
     }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      return true;
+    }
     return false;
   }
 
@@ -277,6 +322,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       case status:
         return null;
       case last_heartbeat:
+        return null;
+      case last_heartbeat_epoch:
         return null;
     }
     throw new IllegalStateException("Invalid field: " + field);
@@ -309,6 +356,7 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
         + " host: " + getHost()
         + " status: " + getStatus()
         + " last_heartbeat: " + getLastHeartbeat()
+        + " last_heartbeat_epoch: " + getLastHeartbeatEpoch()
         + ">";
   }
 
@@ -324,17 +372,26 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 923501707333523410L;
+    public static final long serialVersionUID = -6062746735172100773L;
 
     // Fields
     private String __host;
     private int __status;
     private long __last_heartbeat;
+    private Long __last_heartbeat_epoch;
 
     public Attributes(long id) {
       super(id);
     }
 
+    public Attributes(long id, final String host, final int status, final long last_heartbeat, final Long last_heartbeat_epoch) {
+      super(id);
+      this.__host = host;
+      this.__status = status;
+      this.__last_heartbeat = last_heartbeat;
+      this.__last_heartbeat_epoch = last_heartbeat_epoch;
+    }
+    
     public Attributes(long id, final String host, final int status, final long last_heartbeat) {
       super(id);
       this.__host = host;
@@ -351,9 +408,11 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       String host = (String)fieldsMap.get(BackgroundWorkflowExecutorInfo._Fields.host);
       int status = (Integer)fieldsMap.get(BackgroundWorkflowExecutorInfo._Fields.status);
       long last_heartbeat = (Long)fieldsMap.get(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat);
+      Long last_heartbeat_epoch = (Long)fieldsMap.get(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch);
       this.__host = host;
       this.__status = status;
       this.__last_heartbeat = last_heartbeat;
+      this.__last_heartbeat_epoch = last_heartbeat_epoch;
     }
 
     public Attributes(Attributes other) {
@@ -361,6 +420,7 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       this.__host = other.getHost();
       this.__status = other.getStatus();
       this.__last_heartbeat = other.getLastHeartbeat();
+      this.__last_heartbeat_epoch = other.getLastHeartbeatEpoch();
     }
 
     public String getHost() {
@@ -393,6 +453,16 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       return this;
     }
 
+    public Long getLastHeartbeatEpoch() {
+      return __last_heartbeat_epoch;
+    }
+
+    public Attributes setLastHeartbeatEpoch(Long newval) {
+      this.__last_heartbeat_epoch = newval;
+      cachedHashCode = 0;
+      return this;
+    }
+
     public void setField(_Fields field, Object value) {
       switch (field) {
         case host:
@@ -403,6 +473,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
           break;
         case last_heartbeat:
           setLastHeartbeat((Long)value);
+          break;
+        case last_heartbeat_epoch:
+          setLastHeartbeatEpoch((Long)value);
           break;
         default:
           throw new IllegalStateException("Invalid field: " + field);
@@ -422,6 +495,10 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
         setLastHeartbeat((Long)value);
         return;
       }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        setLastHeartbeatEpoch((Long)value);
+        return;
+      }
       throw new IllegalStateException("Invalid field: " + fieldName);
     }
 
@@ -433,6 +510,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
           return int.class;
         case last_heartbeat:
           return long.class;
+        case last_heartbeat_epoch:
+          return Long.class;
         default:
           throw new IllegalStateException("Invalid field: " + field);
       }    
@@ -447,6 +526,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       }
       if (fieldName.equals("last_heartbeat")) {
         return long.class;
+      }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        return Long.class;
       }
       throw new IllegalStateException("Invalid field name: " + fieldName);
     }
@@ -465,6 +547,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       if (fieldName.equals("last_heartbeat")) {
         return getLastHeartbeat();
       }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        return getLastHeartbeatEpoch();
+      }
       throw new IllegalStateException("Invalid field name: " + fieldName);
     }
 
@@ -476,6 +561,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
           return getStatus();
         case last_heartbeat:
           return getLastHeartbeat();
+        case last_heartbeat_epoch:
+          return getLastHeartbeatEpoch();
       }
       throw new IllegalStateException("Invalid field: " + field);
     }
@@ -493,6 +580,9 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
       if (fieldName.equals("last_heartbeat")) {
         return true;
       }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        return true;
+      }
       return false;
     }
 
@@ -503,6 +593,8 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
         case status:
           return null;
         case last_heartbeat:
+          return null;
+        case last_heartbeat_epoch:
           return null;
       }
       throw new IllegalStateException("Invalid field: " + field);
@@ -519,6 +611,7 @@ public class BackgroundWorkflowExecutorInfo extends ModelWithId<BackgroundWorkfl
           + " host: " + getHost()
           + " status: " + getStatus()
           + " last_heartbeat: " + getLastHeartbeat()
+          + " last_heartbeat_epoch: " + getLastHeartbeatEpoch()
           + ">";
     }
   }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/StepAttempt.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/StepAttempt.java
@@ -596,9 +596,9 @@ public class StepAttempt extends ModelWithId<StepAttempt, IDatabases> implements
     return newWorkflowAttempt;
   }
 
-  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) throws IOException {
+  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) throws IOException {
  
-    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
     setWorkflowAttemptId(JackUtility.safeLongToInt(newWorkflowAttempt.getId()));
     save();
     __assoc_workflow_attempt.clearCache();

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAttempt.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAttempt.java
@@ -34,7 +34,7 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> implements Comparable<WorkflowAttempt>{
   
-  public static final long serialVersionUID = 667747487786598594L;
+  public static final long serialVersionUID = -8018805094218720443L;
 
   public static class Tbl extends AbstractTable<WorkflowAttempt.Attributes, WorkflowAttempt> {
     public final Column<Long> ID;
@@ -55,6 +55,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     public final Column<String> SCM_REMOTE;
     public final Column<String> COMMIT_REVISION;
     public final Column<String> DESCRIPTION;
+    public final Column<Long> LAST_HEARTBEAT_EPOCH;
 
     private Tbl(String alias) {
       super("workflow_attempts", alias, WorkflowAttempt.Attributes.class, WorkflowAttempt.class);
@@ -76,7 +77,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       this.SCM_REMOTE = Column.fromField(alias, _Fields.scm_remote, String.class);
       this.COMMIT_REVISION = Column.fromField(alias, _Fields.commit_revision, String.class);
       this.DESCRIPTION = Column.fromField(alias, _Fields.description, String.class);
-      Collections.addAll(this.allColumns, ID, WORKFLOW_EXECUTION_ID, SYSTEM_USER, SHUTDOWN_REASON, PRIORITY, POOL, HOST, START_TIME, END_TIME, STATUS, LAST_HEARTBEAT, LAUNCH_DIR, LAUNCH_JAR, ERROR_EMAIL, INFO_EMAIL, SCM_REMOTE, COMMIT_REVISION, DESCRIPTION);
+      this.LAST_HEARTBEAT_EPOCH = Column.fromField(alias, _Fields.last_heartbeat_epoch, Long.class);
+      Collections.addAll(this.allColumns, ID, WORKFLOW_EXECUTION_ID, SYSTEM_USER, SHUTDOWN_REASON, PRIORITY, POOL, HOST, START_TIME, END_TIME, STATUS, LAST_HEARTBEAT, LAUNCH_DIR, LAUNCH_JAR, ERROR_EMAIL, INFO_EMAIL, SCM_REMOTE, COMMIT_REVISION, DESCRIPTION, LAST_HEARTBEAT_EPOCH);
     }
 
     public static Tbl as(String alias) {
@@ -103,6 +105,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
   public static final Column<String> SCM_REMOTE = TBL.SCM_REMOTE;
   public static final Column<String> COMMIT_REVISION = TBL.COMMIT_REVISION;
   public static final Column<String> DESCRIPTION = TBL.DESCRIPTION;
+  public static final Column<Long> LAST_HEARTBEAT_EPOCH = TBL.LAST_HEARTBEAT_EPOCH;
 
   private final Attributes attributes;
 
@@ -133,6 +136,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     scm_remote,
     commit_revision,
     description,
+    last_heartbeat_epoch,
   }
 
   @Override
@@ -143,9 +147,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     return cachedTypedId;
   }
 
-  public WorkflowAttempt(long id, final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, IDatabases databases) {
+  public WorkflowAttempt(long id, final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch, IDatabases databases) {
     super(databases);
-    attributes = new Attributes(id, workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    attributes = new Attributes(id, workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
     this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
     this.__assoc_step_attempt = new HasManyAssociation<>(databases.getWorkflowDb().stepAttempts(), "workflow_attempt_id", getId());
     this.__assoc_workflow_attempt_datastore = new HasManyAssociation<>(databases.getWorkflowDb().workflowAttemptDatastores(), "workflow_attempt_id", getId());
@@ -153,9 +157,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     this.__assoc_background_attempt_info = new HasOneAssociation<>(databases.getWorkflowDb().backgroundAttemptInfos(), "workflow_attempt_id", getId());
   }
 
-  public WorkflowAttempt(long id, final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) {
+  public WorkflowAttempt(long id, final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) {
     super(null);
-    attributes = new Attributes(id, workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    attributes = new Attributes(id, workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
   }
   
   public WorkflowAttempt(long id, final int workflow_execution_id, final String system_user, final String priority, final String pool, final String host, IDatabases databases) {
@@ -393,6 +397,16 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     return this;
   }
 
+  public Long getLastHeartbeatEpoch() {
+    return attributes.getLastHeartbeatEpoch();
+  }
+
+  public WorkflowAttempt setLastHeartbeatEpoch(Long newval) {
+    attributes.setLastHeartbeatEpoch(newval);
+    cachedHashCode = 0;
+    return this;
+  }
+
   public void setField(_Fields field, Object value) {
     switch (field) {
       case workflow_execution_id:
@@ -445,6 +459,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
         break;
       case description:
         setDescription((String)value);
+        break;
+      case last_heartbeat_epoch:
+        setLastHeartbeatEpoch((Long)value);
         break;
       default:
         throw new IllegalStateException("Invalid field: " + field);
@@ -520,6 +537,10 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       setDescription((String)  value);
       return;
     }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      setLastHeartbeatEpoch((Long)  value);
+      return;
+    }
     throw new IllegalStateException("Invalid field: " + fieldName);
   }
 
@@ -559,6 +580,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
         return String.class;
       case description:
         return String.class;
+      case last_heartbeat_epoch:
+        return Long.class;
       default:
         throw new IllegalStateException("Invalid field: " + field);
     }    
@@ -615,6 +638,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     }
     if (fieldName.equals("description")) {
       return String.class;
+    }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      return Long.class;
     }
     throw new IllegalStateException("Invalid field name: " + fieldName);
   }
@@ -695,6 +721,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     if (fieldName.equals("description")) {
       return getDescription();
     }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      return getLastHeartbeatEpoch();
+    }
     throw new IllegalStateException("Invalid field name: " + fieldName);
   }
 
@@ -734,6 +763,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
         return getCommitRevision();
       case description:
         return getDescription();
+      case last_heartbeat_epoch:
+        return getLastHeartbeatEpoch();
     }
     throw new IllegalStateException("Invalid field: " + field);
   }
@@ -793,6 +824,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     if (fieldName.equals("description")) {
       return true;
     }
+    if (fieldName.equals("last_heartbeat_epoch")) {
+      return true;
+    }
     return false;
   }
 
@@ -831,6 +865,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       case commit_revision:
         return null;
       case description:
+        return null;
+      case last_heartbeat_epoch:
         return null;
     }
     throw new IllegalStateException("Invalid field: " + field);
@@ -904,6 +940,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
         + " scm_remote: " + getScmRemote()
         + " commit_revision: " + getCommitRevision()
         + " description: " + getDescription()
+        + " last_heartbeat_epoch: " + getLastHeartbeatEpoch()
         + ">";
   }
 
@@ -923,7 +960,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = -2752728951613836000L;
+    public static final long serialVersionUID = 2383243373111032074L;
 
     // Fields
     private int __workflow_execution_id;
@@ -943,12 +980,13 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
     private String __scm_remote;
     private String __commit_revision;
     private String __description;
+    private Long __last_heartbeat_epoch;
 
     public Attributes(long id) {
       super(id);
     }
 
-    public Attributes(long id, final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) {
+    public Attributes(long id, final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) {
       super(id);
       this.__workflow_execution_id = workflow_execution_id;
       this.__system_user = system_user;
@@ -967,6 +1005,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       this.__scm_remote = scm_remote;
       this.__commit_revision = commit_revision;
       this.__description = description;
+      this.__last_heartbeat_epoch = last_heartbeat_epoch;
     }
     
     public Attributes(long id, final int workflow_execution_id, final String system_user, final String priority, final String pool, final String host) {
@@ -1001,6 +1040,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       String scm_remote = (String)fieldsMap.get(WorkflowAttempt._Fields.scm_remote);
       String commit_revision = (String)fieldsMap.get(WorkflowAttempt._Fields.commit_revision);
       String description = (String)fieldsMap.get(WorkflowAttempt._Fields.description);
+      Long last_heartbeat_epoch = (Long)fieldsMap.get(WorkflowAttempt._Fields.last_heartbeat_epoch);
       this.__workflow_execution_id = workflow_execution_id;
       this.__system_user = system_user;
       this.__shutdown_reason = shutdown_reason;
@@ -1018,6 +1058,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       this.__scm_remote = scm_remote;
       this.__commit_revision = commit_revision;
       this.__description = description;
+      this.__last_heartbeat_epoch = last_heartbeat_epoch;
     }
 
     public Attributes(Attributes other) {
@@ -1039,6 +1080,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       this.__scm_remote = other.getScmRemote();
       this.__commit_revision = other.getCommitRevision();
       this.__description = other.getDescription();
+      this.__last_heartbeat_epoch = other.getLastHeartbeatEpoch();
     }
 
     public int getWorkflowExecutionId() {
@@ -1211,6 +1253,16 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       return this;
     }
 
+    public Long getLastHeartbeatEpoch() {
+      return __last_heartbeat_epoch;
+    }
+
+    public Attributes setLastHeartbeatEpoch(Long newval) {
+      this.__last_heartbeat_epoch = newval;
+      cachedHashCode = 0;
+      return this;
+    }
+
     public void setField(_Fields field, Object value) {
       switch (field) {
         case workflow_execution_id:
@@ -1263,6 +1315,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
           break;
         case description:
           setDescription((String)value);
+          break;
+        case last_heartbeat_epoch:
+          setLastHeartbeatEpoch((Long)value);
           break;
         default:
           throw new IllegalStateException("Invalid field: " + field);
@@ -1338,6 +1393,10 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
         setDescription((String)value);
         return;
       }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        setLastHeartbeatEpoch((Long)value);
+        return;
+      }
       throw new IllegalStateException("Invalid field: " + fieldName);
     }
 
@@ -1377,6 +1436,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
           return String.class;
         case description:
           return String.class;
+        case last_heartbeat_epoch:
+          return Long.class;
         default:
           throw new IllegalStateException("Invalid field: " + field);
       }    
@@ -1433,6 +1494,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       }
       if (fieldName.equals("description")) {
         return String.class;
+      }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        return Long.class;
       }
       throw new IllegalStateException("Invalid field name: " + fieldName);
     }
@@ -1493,6 +1557,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       if (fieldName.equals("description")) {
         return getDescription();
       }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        return getLastHeartbeatEpoch();
+      }
       throw new IllegalStateException("Invalid field name: " + fieldName);
     }
 
@@ -1532,6 +1599,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
           return getCommitRevision();
         case description:
           return getDescription();
+        case last_heartbeat_epoch:
+          return getLastHeartbeatEpoch();
       }
       throw new IllegalStateException("Invalid field: " + field);
     }
@@ -1591,6 +1660,9 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
       if (fieldName.equals("description")) {
         return true;
       }
+      if (fieldName.equals("last_heartbeat_epoch")) {
+        return true;
+      }
       return false;
     }
 
@@ -1630,6 +1702,8 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
           return null;
         case description:
           return null;
+        case last_heartbeat_epoch:
+          return null;
       }
       throw new IllegalStateException("Invalid field: " + field);
     }
@@ -1659,6 +1733,7 @@ public class WorkflowAttempt extends ModelWithId<WorkflowAttempt, IDatabases> im
           + " scm_remote: " + getScmRemote()
           + " commit_revision: " + getCommitRevision()
           + " description: " + getDescription()
+          + " last_heartbeat_epoch: " + getLastHeartbeatEpoch()
           + ">";
     }
   }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAttemptConfiguredNotification.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAttemptConfiguredNotification.java
@@ -317,9 +317,9 @@ public class WorkflowAttemptConfiguredNotification extends ModelWithId<WorkflowA
     return newWorkflowAttempt;
   }
 
-  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) throws IOException {
+  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) throws IOException {
  
-    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
     setWorkflowAttemptId(newWorkflowAttempt.getId());
     save();
     __assoc_workflow_attempt.clearCache();

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAttemptDatastore.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAttemptDatastore.java
@@ -359,9 +359,9 @@ public class WorkflowAttemptDatastore extends ModelWithId<WorkflowAttemptDatasto
     return newWorkflowAttempt;
   }
 
-  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description) throws IOException {
+  public WorkflowAttempt createWorkflowAttempt(final int workflow_execution_id, final String system_user, final String shutdown_reason, final String priority, final String pool, final String host, final Long start_time, final Long end_time, final Integer status, final Long last_heartbeat, final String launch_dir, final String launch_jar, final String error_email, final String info_email, final String scm_remote, final String commit_revision, final String description, final Long last_heartbeat_epoch) throws IOException {
  
-    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description);
+    WorkflowAttempt newWorkflowAttempt = databases.getWorkflowDb().workflowAttempts().create(workflow_execution_id, system_user, shutdown_reason, priority, pool, host, start_time, end_time, status, last_heartbeat, launch_dir, launch_jar, error_email, info_email, scm_remote, commit_revision, description, last_heartbeat_epoch);
     setWorkflowAttemptId(JackUtility.safeLongToInt(newWorkflowAttempt.getId()));
     save();
     __assoc_workflow_attempt.clearCache();

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/BackgroundWorkflowExecutorInfoDeleteBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/BackgroundWorkflowExecutorInfoDeleteBuilder.java
@@ -60,4 +60,14 @@ public class BackgroundWorkflowExecutorInfoDeleteBuilder extends AbstractDeleteB
     addWhereConstraint(new WhereConstraint<Long>(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat, operator));
     return this;
   }
+
+  public BackgroundWorkflowExecutorInfoDeleteBuilder lastHeartbeatEpoch(Long value) {
+    addWhereConstraint(new WhereConstraint<Long>(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch, JackMatchers.equalTo(value)));
+    return this;
+  }
+
+  public BackgroundWorkflowExecutorInfoDeleteBuilder whereLastHeartbeatEpoch(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch, operator));
+    return this;
+  }
 }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/BackgroundWorkflowExecutorInfoQueryBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/BackgroundWorkflowExecutorInfoQueryBuilder.java
@@ -147,4 +147,24 @@ public class BackgroundWorkflowExecutorInfoQueryBuilder extends AbstractQueryBui
     this.addOrder(new OrderCriterion(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat, queryOrder));
     return this;
   }
+
+  public BackgroundWorkflowExecutorInfoQueryBuilder lastHeartbeatEpoch(Long value) {
+    addWhereConstraint(new WhereConstraint<>(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch, JackMatchers.equalTo(value)));
+    return this;
+  }
+
+  public BackgroundWorkflowExecutorInfoQueryBuilder whereLastHeartbeatEpoch(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<>(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch, operator));
+    return this;
+  }
+
+  public BackgroundWorkflowExecutorInfoQueryBuilder orderByLastHeartbeatEpoch() {
+    this.addOrder(new OrderCriterion(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch, QueryOrder.ASC));
+    return this;
+  }
+
+  public BackgroundWorkflowExecutorInfoQueryBuilder orderByLastHeartbeatEpoch(QueryOrder queryOrder) {
+    this.addOrder(new OrderCriterion(BackgroundWorkflowExecutorInfo._Fields.last_heartbeat_epoch, queryOrder));
+    return this;
+  }
 }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAttemptDeleteBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAttemptDeleteBuilder.java
@@ -200,4 +200,14 @@ public class WorkflowAttemptDeleteBuilder extends AbstractDeleteBuilder<Workflow
     addWhereConstraint(new WhereConstraint<String>(WorkflowAttempt._Fields.description, operator));
     return this;
   }
+
+  public WorkflowAttemptDeleteBuilder lastHeartbeatEpoch(Long value) {
+    addWhereConstraint(new WhereConstraint<Long>(WorkflowAttempt._Fields.last_heartbeat_epoch, JackMatchers.equalTo(value)));
+    return this;
+  }
+
+  public WorkflowAttemptDeleteBuilder whereLastHeartbeatEpoch(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<Long>(WorkflowAttempt._Fields.last_heartbeat_epoch, operator));
+    return this;
+  }
 }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAttemptQueryBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAttemptQueryBuilder.java
@@ -427,4 +427,24 @@ public class WorkflowAttemptQueryBuilder extends AbstractQueryBuilder<WorkflowAt
     this.addOrder(new OrderCriterion(WorkflowAttempt._Fields.description, queryOrder));
     return this;
   }
+
+  public WorkflowAttemptQueryBuilder lastHeartbeatEpoch(Long value) {
+    addWhereConstraint(new WhereConstraint<>(WorkflowAttempt._Fields.last_heartbeat_epoch, JackMatchers.equalTo(value)));
+    return this;
+  }
+
+  public WorkflowAttemptQueryBuilder whereLastHeartbeatEpoch(IWhereOperator<Long> operator) {
+    addWhereConstraint(new WhereConstraint<>(WorkflowAttempt._Fields.last_heartbeat_epoch, operator));
+    return this;
+  }
+
+  public WorkflowAttemptQueryBuilder orderByLastHeartbeatEpoch() {
+    this.addOrder(new OrderCriterion(WorkflowAttempt._Fields.last_heartbeat_epoch, QueryOrder.ASC));
+    return this;
+  }
+
+  public WorkflowAttemptQueryBuilder orderByLastHeartbeatEpoch(QueryOrder queryOrder) {
+    this.addOrder(new OrderCriterion(WorkflowAttempt._Fields.last_heartbeat_epoch, queryOrder));
+    return this;
+  }
 }

--- a/workflow_hadoop/src/test/java/com/liveramp/workflow/state/WorkflowDbPersistenceFactoryIT.java
+++ b/workflow_hadoop/src/test/java/com/liveramp/workflow/state/WorkflowDbPersistenceFactoryIT.java
@@ -4,19 +4,21 @@ import java.io.IOException;
 import java.util.List;
 
 import com.google.common.collect.Sets;
-import com.liveramp.databases.workflow_db.DatabasesImpl;
-import com.liveramp.databases.workflow_db.IWorkflowDb;
-import com.liveramp.databases.workflow_db.models.*;
 import org.apache.hadoop.util.Time;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.liveramp.commons.Accessors;
+import com.liveramp.databases.workflow_db.DatabasesImpl;
+import com.liveramp.databases.workflow_db.IWorkflowDb;
+import com.liveramp.databases.workflow_db.models.Application;
+import com.liveramp.databases.workflow_db.models.StepAttempt;
+import com.liveramp.databases.workflow_db.models.WorkflowAttempt;
+import com.liveramp.databases.workflow_db.models.WorkflowExecution;
 import com.liveramp.workflow.types.StepStatus;
 import com.liveramp.workflow.types.WorkflowAttemptStatus;
 import com.liveramp.workflow.types.WorkflowExecutionStatus;
 import com.liveramp.workflow_db_state.DbPersistence;
-import com.liveramp.workflow_state.WorkflowRunnerNotification;
 import com.rapleaf.cascading_ext.workflow2.Step;
 import com.rapleaf.cascading_ext.workflow2.WorkflowRunner;
 import com.rapleaf.cascading_ext.workflow2.WorkflowTestCase;
@@ -58,9 +60,11 @@ public class WorkflowDbPersistenceFactoryIT extends WorkflowTestCase {
 
     long currentTime = System.currentTimeMillis();
 
+    long hb = currentTime - (DbPersistence.HEARTBEAT_INTERVAL * DbPersistence.NUM_HEARTBEAT_TIMEOUTS * 2);
     WorkflowAttempt workflowAttempt = workflow_db.workflowAttempts().create(ex.getIntId(), "bpodgursky", "default", "default", "localhost")
         .setStatus(dead.ordinal())
-        .setLastHeartbeat(currentTime - (DbPersistence.HEARTBEAT_INTERVAL * DbPersistence.NUM_HEARTBEAT_TIMEOUTS * 2));
+        .setLastHeartbeat(hb)
+        .setLastHeartbeatEpoch(hb);
     workflowAttempt.save();
 
     StepAttempt stepAttempt = workflow_db.stepAttempts().create(workflowAttempt.getIntId(), "step1", StepStatus.RUNNING.ordinal(), Object.class.getName());
@@ -126,9 +130,11 @@ public class WorkflowDbPersistenceFactoryIT extends WorkflowTestCase {
 
     long currentTime = System.currentTimeMillis();
 
+    long hb = currentTime - (DbPersistence.HEARTBEAT_INTERVAL * 2);
     WorkflowAttempt workflowAttempt = workflow_db.workflowAttempts().create((int)ex.getId(), "bpodgursky", "default", "default", "localhost")
         .setStatus(WorkflowAttemptStatus.RUNNING.ordinal())
-        .setLastHeartbeat(currentTime - (DbPersistence.HEARTBEAT_INTERVAL * 2));
+        .setLastHeartbeat(hb)
+        .setLastHeartbeatEpoch(hb);
     workflowAttempt.save();
 
     workflow_db.stepAttempts().create((int)workflowAttempt.getId(), "step1", StepStatus.RUNNING.ordinal(), Object.class.getName());
@@ -163,8 +169,10 @@ public class WorkflowDbPersistenceFactoryIT extends WorkflowTestCase {
 
     long currentTime = System.currentTimeMillis();
 
+    long hb = currentTime - (DbPersistence.HEARTBEAT_INTERVAL * 2);
     WorkflowAttempt workflowAttempt = workflow_db.workflowAttempts().create((int)ex.getId(), "bpodgursky", "default", "default", "localhost")
-        .setLastHeartbeat(currentTime - (DbPersistence.HEARTBEAT_INTERVAL * 2));
+        .setLastHeartbeat(hb)
+        .setLastHeartbeatEpoch(hb);
     workflowAttempt.save();
 
     workflow_db.stepAttempts().create((int)workflowAttempt.getId(), "step1", StepStatus.RUNNING.ordinal(), Object.class.getName());

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/CoreWorkflowDbPersistenceFactory.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/CoreWorkflowDbPersistenceFactory.java
@@ -301,9 +301,12 @@ public abstract class CoreWorkflowDbPersistenceFactory<S extends IStep,
         .setCommitRevision(implementationBuild);
 
     if (manager.isLive()) {
-      attempt.setLastHeartbeat(System.currentTimeMillis());
+      long hb = System.currentTimeMillis();
+      attempt.setLastHeartbeat(hb)
+          .setLastHeartbeatEpoch(hb);
     }else{
-      attempt.setLastHeartbeat(0L);
+      attempt.setLastHeartbeat(0L)
+          .setLastHeartbeatEpoch(0L);
     }
 
     attempt.save();

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/InitializedDbPersistence.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/InitializedDbPersistence.java
@@ -188,8 +188,10 @@ public class InitializedDbPersistence implements InitializedPersistence {
   private void heartbeat() {
     synchronized (lock) {
       try {
+        long hb = System.currentTimeMillis();
         save(getAttempt()
-            .setLastHeartbeat(System.currentTimeMillis())
+            .setLastHeartbeat(hb)
+            .setLastHeartbeatEpoch(hb)
         );
       } catch (IOException e) {
         LOG.error("Failed to record heartbeat: ", e);

--- a/workflow_state/src/main/java/com/liveramp/workflow_state/background_workflow/BackgroundWorkflowExecutor.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_state/background_workflow/BackgroundWorkflowExecutor.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -54,6 +55,7 @@ import com.liveramp.workflow_core.background_workflow.BackgroundAction;
 import com.liveramp.workflow_core.background_workflow.PreconditionFunction;
 import com.liveramp.workflow_db_state.DbPersistence;
 import com.liveramp.workflow_db_state.InitializedDbPersistence;
+import com.liveramp.workflow_db_state.WorkflowQueries;
 import com.liveramp.workflow_state.WorkflowStatePersistence;
 import com.rapleaf.jack.AttributesWithId;
 import com.rapleaf.jack.queries.Column;
@@ -180,7 +182,7 @@ public class BackgroundWorkflowExecutor {
               .find(workerID);
 
           long currentTime = System.currentTimeMillis();
-          long lastHeartbeat = workerInfo.getLastHeartbeat();
+          long lastHeartbeat = WorkflowQueries.getLastHeartbeat(workerInfo);
 
           long timeElapsed = currentTime - lastHeartbeat;
           if (timeElapsed > heartbeatTimeoutMs) {
@@ -189,6 +191,7 @@ public class BackgroundWorkflowExecutor {
 
           workerInfo
               .setLastHeartbeat(currentTime)
+              .setLastHeartbeatEpoch(currentTime)
               .save();
 
         }

--- a/workflow_ui/src/test/java/com/liveramp/workflow_ui/scripts/SweepOldExecutionsIT.java
+++ b/workflow_ui/src/test/java/com/liveramp/workflow_ui/scripts/SweepOldExecutionsIT.java
@@ -109,6 +109,7 @@ public class SweepOldExecutionsIT extends WorkflowUITestCase {
         null,
         null,
         null,
+        null,
         null
     );
 


### PR DESCRIPTION
Because comparing dates across timezones is a nightmare if we store anything but the epoch.
This change is backwards comptaible. Everywhere that calls `setLastHeartbeat` also calls
`setLastHeartbeatEpoch` (verified with `rg 'setLastHeartbeat' workflow_assemblies/ workflow_core/ workflow_hadoop/ workflow_monitor/ workflow_ui workflow_state -C1`).

Anywhere that tries to use a heart tries to use the epoch heartbeat, and falls back to the datetime
heartbeat if none is found. This keeps backwards compatibility while clients migrate. Verified with
`ag 'getLastHeartbeat' workflow_assemblies/ workflow_core/ workflow_hadoop/ workflow_monitor/ workflow_ui workflow_state -C1`