### PR TITLE
Fix migration container

### DIFF
--- a/workflow_db/container/migration/Dockerfile
+++ b/workflow_db/container/migration/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install rh-ruby23 rh-ruby23-ruby-devel patch
 
 SHELL [ "/usr/bin/scl", "enable", "rh-ruby23" ]
 
-RUN yum -y install make gcc mysql-devel gcc-c++ mysql
+RUN yum -y install make gcc mysql-devel gcc-c++ mysql gettext
 
 RUN gem install bundler
 

--- a/workflow_db/container/migration/entrypoint.sh
+++ b/workflow_db/container/migration/entrypoint.sh
@@ -1,18 +1,14 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 DIR="${0%/*}"
 
 # wait for mysql
 source "$DIR/block-on-db.sh"
 
 # set up the database files from environment vars
-sed -e "s/\${DB_USERNAME}/$DB_USERNAME/" \
-  -e "s/\${DB_PASSWORD}/$DB_PASSWORD/" \
-  -e "s/\${DB_HOSTNAME}/$DB_HOSTNAME/" \
-  -e "s/\${DB_PORT}/$DB_PORT/" \
-  /apps/workflow_db/config/database.yml.tpl \
-  > /apps/workflow_db/config/database.yml
-
+cat /apps/workflow_db/config/database.yml.tpl | envsubst > /apps/workflow_db/config/database.yml
 
 # set up the rails db
 export RAILS_ENV=docker_env

--- a/workflow_db/database/config/database.yml.tpl
+++ b/workflow_db/database/config/database.yml.tpl
@@ -10,8 +10,8 @@ login: &login
 
 workflow_docker_env:
   <<: *login
-  database: workflow_docker_env
+  database: ${DB_NAME}
 
 docker_env:
   <<: *login
-  database: workflow_docker_env
+  database: ${DB_NAME}


### PR DESCRIPTION
- Don't start the pod if DB migrations fails
- use `envsubst` instead of `sed` to handle passwords with '/' characters
- Get database name from the environment