### PR TITLE
Release docker images with tags that correspond to maven artifact versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Workflow2 began (many, many years ago) as a simple in-memory DAG processor, and 
 
 A production deployment of workflow2 has a few moving parts:
 
-- the __Workflow DB__ is a database which holds all system state
+- The __Workflow DB__ is a database which holds all system state
 
 - The __Workflow UI__ is a web interface to allow users to view and modify system state
 
@@ -180,7 +180,7 @@ This is great, but what happens if a workflow fails halfway through?  Let's say 
 
 ![alt text](images/failed.png)
 
-When we call `.run` on a Workflow, it either _resumes_ an incomplete Execution or creates a new Execution:
+When we call `.run` on a Workflow, it either _resumes_ an incomplete Execution or creates a _new_ Execution:
 
 - If the last Attempt did not complete the steps it defined, we create a new Attempt in the existing Execution
 

--- a/bin/deploy_images.sh
+++ b/bin/deploy_images.sh
@@ -22,25 +22,25 @@ docker_login() {
 docker_login
 
 # Workflow UI container
-WORKFLOW_UI_REPO="liveramp/workflow2_ui"
+WORKFLOW_UI_REPO="liveramp/workflow2_ui:${VERSION}"
 pushd workflow_ui
-docker build -t workflow2_ui:latest -f Dockerfile .
+docker build -t workflow2_ui:${VERSION} -f Dockerfile .
 docker tag workflow2_ui ${WORKFLOW_UI_REPO}
 docker push ${WORKFLOW_UI_REPO}
 popd
 
 # Workflow monitor container
-WORKFLOW_MONITOR_REPO="liveramp/workflow2_monitor"
+WORKFLOW_MONITOR_REPO="liveramp/workflow2_monitor:${VERSION}"
 pushd workflow_monitor
-docker build -t workflow2_monitor:latest -f Dockerfile .
+docker build -t workflow2_monitor:${VERSION} -f Dockerfile .
 docker tag workflow2_monitor ${WORKFLOW_MONITOR_REPO}
 docker push ${WORKFLOW_MONITOR_REPO}
 popd
 
 # Workflow examples container
-WORKFLOW_EXAMPLES_REPO="liveramp/workflow2_examples"
+WORKFLOW_EXAMPLES_REPO="liveramp/workflow2_examples:${VERSION}"
 pushd workflow_examples
-docker build -t workflow2_examples:latest -f Dockerfile .
+docker build -t workflow2_examples:${VERSION} -f Dockerfile .
 docker tag workflow2_examples ${WORKFLOW_EXAMPLES_REPO}
 docker push ${WORKFLOW_EXAMPLES_REPO}
 popd

--- a/deploy
+++ b/deploy
@@ -37,6 +37,8 @@ gpg --fast-import .travis/gpg.asc
 # Run the maven deploy steps
 mvn deploy -P generate,publish,travis -DskipTests=true --settings "${TRAVIS_BUILD_DIR}/.travis/mvn-settings.xml"
 
+export VERSION=$(mvn -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive exec:exec -q)
+
 # Deploy the workflow_ui and workflow_monitor containers
 ./bin/deploy_images.sh
 

--- a/kubernetes/demo_manifest.yaml
+++ b/kubernetes/demo_manifest.yaml
@@ -112,7 +112,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       # The actual UI container
-      - image: liveramp/workflow2_ui
+      - image: liveramp/workflow2_ui:1.0-SNAPSHOT
         name: workflow2-ui
         imagePullPolicy: "Always"
         ports:
@@ -133,7 +133,7 @@ spec:
           value: /apps/config/application.properties
       # Run database migrations before starting the UI
       initContainers:
-      - image: liveramp/workflow2_db_migrations
+      - image: liveramp/workflow2_db_migrations:1.0-SNAPSHOT
         name: workflow2-db
         env:
         # In production, use real credentials!
@@ -226,7 +226,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: liveramp/workflow2_monitor
+      - image: liveramp/workflow2_monitor:1.0-SNAPSHOT
         name: workflow2-monitor
         imagePullPolicy: "Always"
         volumeMounts:
@@ -299,7 +299,7 @@ spec:
         spec:
           containers:
           - name: example-workflow
-            image: liveramp/workflow2_examples
+            image: liveramp/workflow2_examples:1.0-SNAPSHOT
             resources:
               requests:
                 memory: "1Gi"

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
   <properties>
     <skip.db>true</skip.db>
-    <sqldump.repo>liveramp/workflow2_sqldump:latest</sqldump.repo>
+    <sqldump.repo>liveramp/workflow2_sqldump</sqldump.repo>
   </properties>
 
   <modules>
@@ -133,7 +133,7 @@
               <executable>${project.basedir}/../test_docker/start-db.sh</executable>
               <environmentVariables>
                 <SQLDUMP_REPO>
-                  ${sqldump.repo}
+                  ${sqldump.repo}:${project.version}
                 </SQLDUMP_REPO>
               </environmentVariables>
             </configuration>
@@ -168,7 +168,7 @@
     <profile>
       <id>travis</id>
       <properties>
-        <sqldump.repo>workflow2_sqldump:latest</sqldump.repo>
+        <sqldump.repo>workflow2_sqldump</sqldump.repo>
       </properties>
     </profile>
 

--- a/workflow_db/bin/build-containers.sh
+++ b/workflow_db/bin/build-containers.sh
@@ -4,8 +4,8 @@ set -e
 
 source ${BASH_SOURCE%/*}/shared.sh
 
-docker build -t workflow2_db_migrations:latest -f container/migration/Dockerfile .
-docker tag workflow2_db_migrations:latest ${MIGRATION_REPO}
+docker build -t workflow2_db_migrations:${VERSION} -f container/migration/Dockerfile .
+docker tag workflow2_db_migrations:${VERSION} ${MIGRATION_REPO}
 
-docker build -t workflow2_sqldump:latest -f container/sqldump/Dockerfile .
-docker tag workflow2_sqldump:latest ${SQLDUMP_REPO}
+docker build -t workflow2_sqldump:${VERSION} -f container/sqldump/Dockerfile .
+docker tag workflow2_sqldump:${VERSION} ${SQLDUMP_REPO}

--- a/workflow_db/bin/shared.sh
+++ b/workflow_db/bin/shared.sh
@@ -18,5 +18,5 @@ docker_login() {
 
 docker_login
 
-export MIGRATION_REPO=liveramp/workflow2_db_migrations
-export SQLDUMP_REPO=liveramp/workflow2_sqldump
+export MIGRATION_REPO=liveramp/workflow2_db_migrations:${VERSION}
+export SQLDUMP_REPO=liveramp/workflow2_sqldump:${VERSION}

--- a/workflow_db/pom.xml
+++ b/workflow_db/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>com.liveramp</groupId>
       <artifactId>jack-mysql</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -45,6 +45,9 @@
             </goals>
             <configuration>
               <executable>${project.basedir}/bin/build-containers.sh</executable>
+              <environmentVariables>
+                <VERSION>${project.version}</VERSION>
+              </environmentVariables>
             </configuration>
           </execution>
           <execution>
@@ -55,6 +58,9 @@
             </goals>
             <configuration>
               <executable>${project.basedir}/bin/push-containers.sh</executable>
+              <environmentVariables>
+                <VERSION>${project.version}</VERSION>
+              </environmentVariables>
             </configuration>
           </execution>
 

--- a/workflow_examples/pom.xml
+++ b/workflow_examples/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.liveramp</groupId>
       <artifactId>mail_utils</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.0</version>
     </dependency>
 
   </dependencies>

--- a/workflow_monitor/pom.xml
+++ b/workflow_monitor/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.liveramp</groupId>
       <artifactId>mail_utils</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
The goal here is to release docker images for the UI, monitor and db containers with tags that correspond 1-1 with the Maven release artifacts, on both SNAPSHOT and release builds.  

This way, when we do a maven artifact release (ex 1.0) we can get "real" docker versioned artifacts, while still consuming the snapshot artifacts.