### PR TITLE
Fix commit link for UI

### DIFF
--- a/workflow_ui/src/main/resources/com/liveramp/workflow_ui/www/js/common.js
+++ b/workflow_ui/src/main/resources/com/liveramp/workflow_ui/www/js/common.js
@@ -136,8 +136,8 @@ function truncateTo(string, length) {
 function commitLink(attempt) {
   if (attempt.scm_remote) {
 
-    //attempt.scm_remote assumed to be of the form git@X:Y/../Z/git or a http link
-    var re = /(git@(\S+?):(\S+?\/\S+?)\.git)|(https?:\/\/\S+)/;
+    //attempt.scm_remote assumed to be of the form git@X:Y/../Z/git or a https link.git
+    var re = /(git@(\S+?):(\S+?\/\S+?)\.git)|(https?:\/\/\S+)\.git/;
     var found = attempt.scm_remote.match(re);
     if (!found) {
       return "";


### PR DESCRIPTION
If I'm understanding the ordering of the capture groups, I believe this should fix some issues where I'm seeing workflows are linking to:
https://github.com/LiveRamp/soa_refresher.git/commits/<COMMIT_ID>
as opposed to 
https://github.com/LiveRamp/soa_refresher/commits/<COMMIT_ID>

This change would just mean that links from `attempt.scm_remote` would just have to end with a `.git`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/workflow2/23)
<!-- Reviewable:end -->
