### PR TITLE
Deprecate the usage of WorkflowRunner to discourage public usage.

### DIFF
--- a/workflow_hadoop/src/main/java/com/rapleaf/cascading_ext/workflow2/WorkflowRunner.java
+++ b/workflow_hadoop/src/main/java/com/rapleaf/cascading_ext/workflow2/WorkflowRunner.java
@@ -21,6 +21,11 @@ import com.rapleaf.cascading_ext.workflow2.options.HadoopWorkflowOptions;
 import com.rapleaf.cascading_ext.workflow2.state.InitializedWorkflow;
 import com.rapleaf.cascading_ext.workflow2.state.WorkflowPersistenceFactory;
 
+/**
+ * Use {@link WorkflowRunners} instead.
+ * This is deprecated for public (outside of this package) usage due to connection leaks.
+ */
+@Deprecated
 public final class WorkflowRunner extends BaseWorkflowRunner<WorkflowRunner.ExecuteConfig> {
   private static final Logger LOG = LoggerFactory.getLogger(WorkflowRunner.class);
 

--- a/workflow_hadoop/src/main/java/com/rapleaf/cascading_ext/workflow2/WorkflowRunners.java
+++ b/workflow_hadoop/src/main/java/com/rapleaf/cascading_ext/workflow2/WorkflowRunners.java
@@ -16,7 +16,6 @@ import com.rapleaf.cascading_ext.workflow2.state.HdfsInitializedPersistence;
 import com.rapleaf.cascading_ext.workflow2.state.InitializedWorkflow;
 import com.rapleaf.cascading_ext.workflow2.state.WorkflowPersistenceFactory;
 
-//  TODO if this officially covers all cases, should deprecate other constructors (or delete this comment if it's too annoying)
 public class WorkflowRunners {
 
   public static void dbRun(


### PR DESCRIPTION
This should ideally be moved to package access level, but this is nearly
impossible without versioned artifacts because it will break many
projects. Instead I'm deprecating it to actively inform users that they
should be using something else to avoid leaking connections.