### PR TITLE
[Sweeping 1 / 5] Add foreign keys for workflow_execution_id

### DIFF
--- a/workflow_db/database/db/migrate/20191009005857_workflow_execution_id_fk.rb
+++ b/workflow_db/database/db/migrate/20191009005857_workflow_execution_id_fk.rb
@@ -1,0 +1,12 @@
+class WorkflowExecutionIdFk < ActiveRecord::Migration
+  def change
+    change_column :execution_tags, :workflow_execution_id, :integer, limit: 4
+    change_column :workflow_execution_configured_notifications, :workflow_execution_id, :integer, limit: 4
+    change_column :workflow_alert_workflow_executions, :workflow_execution_id, :integer, limit: 4
+
+    add_foreign_key :workflow_attempts, :workflow_executions, on_delete: :cascade
+    add_foreign_key :execution_tags, :workflow_executions, on_delete: :cascade
+    add_foreign_key :workflow_execution_configured_notifications, :workflow_executions, on_delete: :cascade
+    add_foreign_key :workflow_alert_workflow_executions, :workflow_executions, on_delete: :cascade
+  end
+end

--- a/workflow_db/database/db/schema.rb
+++ b/workflow_db/database/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190612183248) do
+ActiveRecord::Schema.define(version: 20191009005857) do
 
   create_table "application_configured_notifications", force: :cascade do |t|
     t.integer "application_id",             limit: 8, null: false
@@ -91,7 +91,7 @@ ActiveRecord::Schema.define(version: 20190612183248) do
   add_index "dashboards", ["name"], name: "index_dashboards_on_name", unique: true, using: :btree
 
   create_table "execution_tags", force: :cascade do |t|
-    t.integer "workflow_execution_id", limit: 8,     null: false
+    t.integer "workflow_execution_id", limit: 4,     null: false
     t.text    "tag",                   limit: 65535, null: false
     t.text    "value",                 limit: 65535, null: false
   end
@@ -228,7 +228,7 @@ ActiveRecord::Schema.define(version: 20190612183248) do
 
   create_table "workflow_alert_workflow_executions", force: :cascade do |t|
     t.integer "workflow_alert_id",     limit: 8, null: false
-    t.integer "workflow_execution_id", limit: 8, null: false
+    t.integer "workflow_execution_id", limit: 4, null: false
   end
 
   add_index "workflow_alert_workflow_executions", ["workflow_alert_id", "workflow_execution_id"], name: "index_wf_alerts_and_executions", using: :btree
@@ -282,7 +282,7 @@ ActiveRecord::Schema.define(version: 20190612183248) do
   add_index "workflow_attempts", ["workflow_execution_id"], name: "workflow_execution_id_index", using: :btree
 
   create_table "workflow_execution_configured_notifications", force: :cascade do |t|
-    t.integer "workflow_execution_id",      limit: 8, null: false
+    t.integer "workflow_execution_id",      limit: 4, null: false
     t.integer "configured_notification_id", limit: 8, null: false
   end
 
@@ -308,4 +308,8 @@ ActiveRecord::Schema.define(version: 20190612183248) do
   add_index "workflow_executions", ["name", "scope_identifier", "status"], name: "name_scope_status", using: :btree
   add_index "workflow_executions", ["start_time"], name: "start_time_idx", using: :btree
 
+  add_foreign_key "execution_tags", "workflow_executions", on_delete: :cascade
+  add_foreign_key "workflow_alert_workflow_executions", "workflow_executions", on_delete: :cascade
+  add_foreign_key "workflow_attempts", "workflow_executions", on_delete: :cascade
+  add_foreign_key "workflow_execution_configured_notifications", "workflow_executions", on_delete: :cascade
 end

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IExecutionTagPersistence.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IExecutionTagPersistence.java
@@ -17,10 +17,10 @@ import java.util.List;
 import com.rapleaf.jack.IModelPersistence;
 
 public interface IExecutionTagPersistence extends IModelPersistence<ExecutionTag> {
-  ExecutionTag create(final long workflow_execution_id, final String tag, final String value) throws IOException;
+  ExecutionTag create(final int workflow_execution_id, final String tag, final String value) throws IOException;
 
   ExecutionTag createDefaultInstance() throws IOException;
-  List<ExecutionTag> findByWorkflowExecutionId(long value)  throws IOException;
+  List<ExecutionTag> findByWorkflowExecutionId(int value)  throws IOException;
   List<ExecutionTag> findByTag(String value)  throws IOException;
   List<ExecutionTag> findByValue(String value)  throws IOException;
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IWorkflowAlertWorkflowExecutionPersistence.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IWorkflowAlertWorkflowExecutionPersistence.java
@@ -17,11 +17,11 @@ import java.util.List;
 import com.rapleaf.jack.IModelPersistence;
 
 public interface IWorkflowAlertWorkflowExecutionPersistence extends IModelPersistence<WorkflowAlertWorkflowExecution> {
-  WorkflowAlertWorkflowExecution create(final long workflow_alert_id, final long workflow_execution_id) throws IOException;
+  WorkflowAlertWorkflowExecution create(final long workflow_alert_id, final int workflow_execution_id) throws IOException;
 
   WorkflowAlertWorkflowExecution createDefaultInstance() throws IOException;
   List<WorkflowAlertWorkflowExecution> findByWorkflowAlertId(long value)  throws IOException;
-  List<WorkflowAlertWorkflowExecution> findByWorkflowExecutionId(long value)  throws IOException;
+  List<WorkflowAlertWorkflowExecution> findByWorkflowExecutionId(int value)  throws IOException;
 
   WorkflowAlertWorkflowExecutionQueryBuilder query();
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IWorkflowExecutionConfiguredNotificationPersistence.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/iface/IWorkflowExecutionConfiguredNotificationPersistence.java
@@ -17,10 +17,10 @@ import java.util.List;
 import com.rapleaf.jack.IModelPersistence;
 
 public interface IWorkflowExecutionConfiguredNotificationPersistence extends IModelPersistence<WorkflowExecutionConfiguredNotification> {
-  WorkflowExecutionConfiguredNotification create(final long workflow_execution_id, final long configured_notification_id) throws IOException;
+  WorkflowExecutionConfiguredNotification create(final int workflow_execution_id, final long configured_notification_id) throws IOException;
 
   WorkflowExecutionConfiguredNotification createDefaultInstance() throws IOException;
-  List<WorkflowExecutionConfiguredNotification> findByWorkflowExecutionId(long value)  throws IOException;
+  List<WorkflowExecutionConfiguredNotification> findByWorkflowExecutionId(int value)  throws IOException;
   List<WorkflowExecutionConfiguredNotification> findByConfiguredNotificationId(long value)  throws IOException;
 
   WorkflowExecutionConfiguredNotificationQueryBuilder query();

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseExecutionTagPersistenceImpl.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseExecutionTagPersistenceImpl.java
@@ -43,13 +43,13 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
 
   @Override
   public ExecutionTag create(Map<Enum, Object> fieldsMap) throws IOException {
-    long workflow_execution_id = (Long) fieldsMap.get(ExecutionTag._Fields.workflow_execution_id);
+    int workflow_execution_id = (Integer) fieldsMap.get(ExecutionTag._Fields.workflow_execution_id);
     String tag = (String) fieldsMap.get(ExecutionTag._Fields.tag);
     String value = (String) fieldsMap.get(ExecutionTag._Fields.value);
     return create(workflow_execution_id, tag, value);
   }
 
-  public ExecutionTag create(final long workflow_execution_id, final String tag, final String value) throws IOException {
+  public ExecutionTag create(final int workflow_execution_id, final String tag, final String value) throws IOException {
     StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
@@ -59,7 +59,7 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
 
         nonNullFields.add("workflow_execution_id");
         int fieldIndex0 = index++;
-        statementSetters.add(stmt -> stmt.setLong(fieldIndex0, workflow_execution_id));
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex0, workflow_execution_id));
 
         nonNullFields.add("tag");
         int fieldIndex1 = index++;
@@ -92,7 +92,7 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
   }
 
   public ExecutionTag createDefaultInstance() throws IOException {
-    return create(0L, "", "");
+    return create(0, "", "");
   }
 
   public List<ExecutionTag> find(Map<Enum, Object> fieldsMap) throws IOException {
@@ -142,7 +142,7 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
         try {
           switch (field) {
             case workflow_execution_id:
-              preparedStatement.setLong(i+1, (Long) nonNullValues.get(i));
+              preparedStatement.setInt(i+1, (Integer) nonNullValues.get(i));
               break;
             case tag:
               preparedStatement.setString(i+1, (String) nonNullValues.get(i));
@@ -184,7 +184,7 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
             ExecutionTag._Fields field = (ExecutionTag._Fields)constraint.getField();
             switch (field) {
               case workflow_execution_id:
-                preparedStatement.setLong(++index, (Long) parameter);
+                preparedStatement.setInt(++index, (Integer) parameter);
                 break;
               case tag:
                 preparedStatement.setString(++index, (String) parameter);
@@ -205,7 +205,7 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
   protected void setAttrs(ExecutionTag model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     {
-      stmt.setLong(index++, model.getWorkflowExecutionId());
+      stmt.setInt(index++, model.getWorkflowExecutionId());
     }
     {
       stmt.setString(index++, model.getTag());
@@ -221,14 +221,14 @@ public class BaseExecutionTagPersistenceImpl extends AbstractDatabaseModel<Execu
     boolean allFields = selectedFields == null || selectedFields.isEmpty();
     long id = rs.getLong("id");
     return new ExecutionTag(id,
-      allFields || selectedFields.contains(ExecutionTag._Fields.workflow_execution_id) ? getLongOrNull(rs, "workflow_execution_id") : 0L,
+      allFields || selectedFields.contains(ExecutionTag._Fields.workflow_execution_id) ? getIntOrNull(rs, "workflow_execution_id") : 0,
       allFields || selectedFields.contains(ExecutionTag._Fields.tag) ? rs.getString("tag") : "",
       allFields || selectedFields.contains(ExecutionTag._Fields.value) ? rs.getString("value") : "",
       databases
     );
   }
 
-  public List<ExecutionTag> findByWorkflowExecutionId(final long value) throws IOException {
+  public List<ExecutionTag> findByWorkflowExecutionId(final int value) throws IOException {
     return find(Collections.<Enum, Object>singletonMap(ExecutionTag._Fields.workflow_execution_id, value));
   }
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseWorkflowAlertWorkflowExecutionPersistenceImpl.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseWorkflowAlertWorkflowExecutionPersistenceImpl.java
@@ -44,11 +44,11 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
   @Override
   public WorkflowAlertWorkflowExecution create(Map<Enum, Object> fieldsMap) throws IOException {
     long workflow_alert_id = (Long) fieldsMap.get(WorkflowAlertWorkflowExecution._Fields.workflow_alert_id);
-    long workflow_execution_id = (Long) fieldsMap.get(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id);
+    int workflow_execution_id = (Integer) fieldsMap.get(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id);
     return create(workflow_alert_id, workflow_execution_id);
   }
 
-  public WorkflowAlertWorkflowExecution create(final long workflow_alert_id, final long workflow_execution_id) throws IOException {
+  public WorkflowAlertWorkflowExecution create(final long workflow_alert_id, final int workflow_execution_id) throws IOException {
     StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
@@ -62,7 +62,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
 
         nonNullFields.add("workflow_execution_id");
         int fieldIndex1 = index++;
-        statementSetters.add(stmt -> stmt.setLong(fieldIndex1, workflow_execution_id));
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex1, workflow_execution_id));
       }
 
       @Override
@@ -87,7 +87,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
   }
 
   public WorkflowAlertWorkflowExecution createDefaultInstance() throws IOException {
-    return create(0L, 0L);
+    return create(0L, 0);
   }
 
   public List<WorkflowAlertWorkflowExecution> find(Map<Enum, Object> fieldsMap) throws IOException {
@@ -140,7 +140,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
               preparedStatement.setLong(i+1, (Long) nonNullValues.get(i));
               break;
             case workflow_execution_id:
-              preparedStatement.setLong(i+1, (Long) nonNullValues.get(i));
+              preparedStatement.setInt(i+1, (Integer) nonNullValues.get(i));
               break;
           }
         } catch (SQLException e) {
@@ -179,7 +179,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
                 preparedStatement.setLong(++index, (Long) parameter);
                 break;
               case workflow_execution_id:
-                preparedStatement.setLong(++index, (Long) parameter);
+                preparedStatement.setInt(++index, (Integer) parameter);
                 break;
             }
           }
@@ -197,7 +197,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
       stmt.setLong(index++, model.getWorkflowAlertId());
     }
     {
-      stmt.setLong(index++, model.getWorkflowExecutionId());
+      stmt.setInt(index++, model.getWorkflowExecutionId());
     }
     stmt.setLong(index, model.getId());
   }
@@ -208,7 +208,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
     long id = rs.getLong("id");
     return new WorkflowAlertWorkflowExecution(id,
       allFields || selectedFields.contains(WorkflowAlertWorkflowExecution._Fields.workflow_alert_id) ? getLongOrNull(rs, "workflow_alert_id") : 0L,
-      allFields || selectedFields.contains(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id) ? getLongOrNull(rs, "workflow_execution_id") : 0L,
+      allFields || selectedFields.contains(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id) ? getIntOrNull(rs, "workflow_execution_id") : 0,
       databases
     );
   }
@@ -217,7 +217,7 @@ public class BaseWorkflowAlertWorkflowExecutionPersistenceImpl extends AbstractD
     return find(Collections.<Enum, Object>singletonMap(WorkflowAlertWorkflowExecution._Fields.workflow_alert_id, value));
   }
 
-  public List<WorkflowAlertWorkflowExecution> findByWorkflowExecutionId(final long value) throws IOException {
+  public List<WorkflowAlertWorkflowExecution> findByWorkflowExecutionId(final int value) throws IOException {
     return find(Collections.<Enum, Object>singletonMap(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, value));
   }
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseWorkflowExecutionConfiguredNotificationPersistenceImpl.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/impl/BaseWorkflowExecutionConfiguredNotificationPersistenceImpl.java
@@ -43,12 +43,12 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
 
   @Override
   public WorkflowExecutionConfiguredNotification create(Map<Enum, Object> fieldsMap) throws IOException {
-    long workflow_execution_id = (Long) fieldsMap.get(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id);
+    int workflow_execution_id = (Integer) fieldsMap.get(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id);
     long configured_notification_id = (Long) fieldsMap.get(WorkflowExecutionConfiguredNotification._Fields.configured_notification_id);
     return create(workflow_execution_id, configured_notification_id);
   }
 
-  public WorkflowExecutionConfiguredNotification create(final long workflow_execution_id, final long configured_notification_id) throws IOException {
+  public WorkflowExecutionConfiguredNotification create(final int workflow_execution_id, final long configured_notification_id) throws IOException {
     StatementCreator statementCreator = new StatementCreator() {
       private final List<String> nonNullFields = new ArrayList<>();
       private final List<AttrSetter> statementSetters = new ArrayList<>();
@@ -58,7 +58,7 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
 
         nonNullFields.add("workflow_execution_id");
         int fieldIndex0 = index++;
-        statementSetters.add(stmt -> stmt.setLong(fieldIndex0, workflow_execution_id));
+        statementSetters.add(stmt -> stmt.setInt(fieldIndex0, workflow_execution_id));
 
         nonNullFields.add("configured_notification_id");
         int fieldIndex1 = index++;
@@ -87,7 +87,7 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
   }
 
   public WorkflowExecutionConfiguredNotification createDefaultInstance() throws IOException {
-    return create(0L, 0L);
+    return create(0, 0L);
   }
 
   public List<WorkflowExecutionConfiguredNotification> find(Map<Enum, Object> fieldsMap) throws IOException {
@@ -137,7 +137,7 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
         try {
           switch (field) {
             case workflow_execution_id:
-              preparedStatement.setLong(i+1, (Long) nonNullValues.get(i));
+              preparedStatement.setInt(i+1, (Integer) nonNullValues.get(i));
               break;
             case configured_notification_id:
               preparedStatement.setLong(i+1, (Long) nonNullValues.get(i));
@@ -176,7 +176,7 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
             WorkflowExecutionConfiguredNotification._Fields field = (WorkflowExecutionConfiguredNotification._Fields)constraint.getField();
             switch (field) {
               case workflow_execution_id:
-                preparedStatement.setLong(++index, (Long) parameter);
+                preparedStatement.setInt(++index, (Integer) parameter);
                 break;
               case configured_notification_id:
                 preparedStatement.setLong(++index, (Long) parameter);
@@ -194,7 +194,7 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
   protected void setAttrs(WorkflowExecutionConfiguredNotification model, PreparedStatement stmt, boolean setNull) throws SQLException {
     int index = 1;
     {
-      stmt.setLong(index++, model.getWorkflowExecutionId());
+      stmt.setInt(index++, model.getWorkflowExecutionId());
     }
     {
       stmt.setLong(index++, model.getConfiguredNotificationId());
@@ -207,13 +207,13 @@ public class BaseWorkflowExecutionConfiguredNotificationPersistenceImpl extends 
     boolean allFields = selectedFields == null || selectedFields.isEmpty();
     long id = rs.getLong("id");
     return new WorkflowExecutionConfiguredNotification(id,
-      allFields || selectedFields.contains(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id) ? getLongOrNull(rs, "workflow_execution_id") : 0L,
+      allFields || selectedFields.contains(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id) ? getIntOrNull(rs, "workflow_execution_id") : 0,
       allFields || selectedFields.contains(WorkflowExecutionConfiguredNotification._Fields.configured_notification_id) ? getLongOrNull(rs, "configured_notification_id") : 0L,
       databases
     );
   }
 
-  public List<WorkflowExecutionConfiguredNotification> findByWorkflowExecutionId(final long value) throws IOException {
+  public List<WorkflowExecutionConfiguredNotification> findByWorkflowExecutionId(final int value) throws IOException {
     return find(Collections.<Enum, Object>singletonMap(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, value));
   }
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/migration-version.txt
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/migration-version.txt
@@ -1,1 +1,1 @@
-Models Generated With Migration: 20190612183248
+Models Generated With Migration: 20191009005857

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/ExecutionTag.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/ExecutionTag.java
@@ -34,18 +34,18 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implements Comparable<ExecutionTag>{
   
-  public static final long serialVersionUID = 8696016204042242944L;
+  public static final long serialVersionUID = -3013231933794313887L;
 
   public static class Tbl extends AbstractTable<ExecutionTag.Attributes, ExecutionTag> {
     public final Column<Long> ID;
-    public final Column<Long> WORKFLOW_EXECUTION_ID;
+    public final Column<Integer> WORKFLOW_EXECUTION_ID;
     public final Column<String> TAG;
     public final Column<String> VALUE;
 
     private Tbl(String alias) {
       super("execution_tags", alias, ExecutionTag.Attributes.class, ExecutionTag.class);
       this.ID = Column.fromId(alias);
-      this.WORKFLOW_EXECUTION_ID = Column.fromField(alias, _Fields.workflow_execution_id, Long.class);
+      this.WORKFLOW_EXECUTION_ID = Column.fromField(alias, _Fields.workflow_execution_id, Integer.class);
       this.TAG = Column.fromField(alias, _Fields.tag, String.class);
       this.VALUE = Column.fromField(alias, _Fields.value, String.class);
       Collections.addAll(this.allColumns, ID, WORKFLOW_EXECUTION_ID, TAG, VALUE);
@@ -58,7 +58,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
 
   public static final Tbl TBL = new Tbl("execution_tags");
   public static final Column<Long> ID = TBL.ID;
-  public static final Column<Long> WORKFLOW_EXECUTION_ID = TBL.WORKFLOW_EXECUTION_ID;
+  public static final Column<Integer> WORKFLOW_EXECUTION_ID = TBL.WORKFLOW_EXECUTION_ID;
   public static final Column<String> TAG = TBL.TAG;
   public static final Column<String> VALUE = TBL.VALUE;
 
@@ -83,19 +83,19 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     return cachedTypedId;
   }
 
-  public ExecutionTag(long id, final long workflow_execution_id, final String tag, final String value, IDatabases databases) {
+  public ExecutionTag(long id, final int workflow_execution_id, final String tag, final String value, IDatabases databases) {
     super(databases);
     attributes = new Attributes(id, workflow_execution_id, tag, value);
-    this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+    this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
   }
 
-  public ExecutionTag(long id, final long workflow_execution_id, final String tag, final String value) {
+  public ExecutionTag(long id, final int workflow_execution_id, final String tag, final String value) {
     super(null);
     attributes = new Attributes(id, workflow_execution_id, tag, value);
   }
 
   public static ExecutionTag newDefaultInstance(long id) {
-    return new ExecutionTag(id, 0L, "", "");
+    return new ExecutionTag(id, 0, "", "");
   }
 
   public ExecutionTag(Attributes attributes, IDatabases databases) {
@@ -103,7 +103,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     this.attributes = attributes;
 
     if (databases != null) {
-      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
     }
   }
 
@@ -125,7 +125,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     attributes = new Attributes(other.getAttributes());
 
     if (databases != null) {
-      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
     }
   }
 
@@ -133,11 +133,11 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     return attributes;
   }
 
-  public long getWorkflowExecutionId() {
+  public int getWorkflowExecutionId() {
     return attributes.getWorkflowExecutionId();
   }
 
-  public ExecutionTag setWorkflowExecutionId(long newval) {
+  public ExecutionTag setWorkflowExecutionId(int newval) {
     attributes.setWorkflowExecutionId(newval);
     if(__assoc_workflow_execution != null){
       this.__assoc_workflow_execution.setOwnerId(newval);
@@ -169,7 +169,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   public void setField(_Fields field, Object value) {
     switch (field) {
       case workflow_execution_id:
-        setWorkflowExecutionId((Long)value);
+        setWorkflowExecutionId((Integer)value);
         break;
       case tag:
         setTag((String)value);
@@ -184,7 +184,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   
   public void setField(String fieldName, Object value) {
     if (fieldName.equals("workflow_execution_id")) {
-      setWorkflowExecutionId((Long)  value);
+      setWorkflowExecutionId((Integer)  value);
       return;
     }
     if (fieldName.equals("tag")) {
@@ -201,7 +201,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   public static Class getFieldType(_Fields field) {
     switch (field) {
       case workflow_execution_id:
-        return long.class;
+        return int.class;
       case tag:
         return String.class;
       case value:
@@ -213,7 +213,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
 
   public static Class getFieldType(String fieldName) {    
     if (fieldName.equals("workflow_execution_id")) {
-      return long.class;
+      return int.class;
     }
     if (fieldName.equals("tag")) {
       return String.class;
@@ -309,7 +309,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   public WorkflowExecution createWorkflowExecution(final String name, final int status) throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create(name, status);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -318,7 +318,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   public WorkflowExecution createWorkflowExecution(final Integer app_type, final String name, final String scope_identifier, final int status, final Long start_time, final Long end_time, final Integer application_id, final String pool_override) throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create(app_type, name, scope_identifier, status, start_time, end_time, application_id, pool_override);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -327,7 +327,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   public WorkflowExecution createWorkflowExecution() throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create("", 0);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -354,10 +354,10 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 6214216292790028403L;
+    public static final long serialVersionUID = -980651832240037827L;
 
     // Fields
-    private long __workflow_execution_id;
+    private int __workflow_execution_id;
     private String __tag;
     private String __value;
 
@@ -365,7 +365,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
       super(id);
     }
 
-    public Attributes(long id, final long workflow_execution_id, final String tag, final String value) {
+    public Attributes(long id, final int workflow_execution_id, final String tag, final String value) {
       super(id);
       this.__workflow_execution_id = workflow_execution_id;
       this.__tag = tag;
@@ -373,12 +373,12 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     }
 
     public static Attributes newDefaultInstance(long id) {
-      return new Attributes(id, 0L, "", "");
+      return new Attributes(id, 0, "", "");
     }
 
     public Attributes(long id, Map<Enum, Object> fieldsMap) {
       super(id);
-      long workflow_execution_id = (Long)fieldsMap.get(ExecutionTag._Fields.workflow_execution_id);
+      int workflow_execution_id = (Integer)fieldsMap.get(ExecutionTag._Fields.workflow_execution_id);
       String tag = (String)fieldsMap.get(ExecutionTag._Fields.tag);
       String value = (String)fieldsMap.get(ExecutionTag._Fields.value);
       this.__workflow_execution_id = workflow_execution_id;
@@ -393,11 +393,11 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
       this.__value = other.getValue();
     }
 
-    public long getWorkflowExecutionId() {
+    public int getWorkflowExecutionId() {
       return __workflow_execution_id;
     }
 
-    public Attributes setWorkflowExecutionId(long newval) {
+    public Attributes setWorkflowExecutionId(int newval) {
       this.__workflow_execution_id = newval;
       cachedHashCode = 0;
       return this;
@@ -426,7 +426,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     public void setField(_Fields field, Object value) {
       switch (field) {
         case workflow_execution_id:
-          setWorkflowExecutionId((Long)value);
+          setWorkflowExecutionId((Integer)value);
           break;
         case tag:
           setTag((String)value);
@@ -441,7 +441,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
 
     public void setField(String fieldName, Object value) {
       if (fieldName.equals("workflow_execution_id")) {
-        setWorkflowExecutionId((Long)value);
+        setWorkflowExecutionId((Integer)value);
         return;
       }
       if (fieldName.equals("tag")) {
@@ -458,7 +458,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
     public static Class getFieldType(_Fields field) {
       switch (field) {
         case workflow_execution_id:
-          return long.class;
+          return int.class;
         case tag:
           return String.class;
         case value:
@@ -470,7 +470,7 @@ public class ExecutionTag extends ModelWithId<ExecutionTag, IDatabases> implemen
 
     public static Class getFieldType(String fieldName) {    
       if (fieldName.equals("workflow_execution_id")) {
-        return long.class;
+        return int.class;
       }
       if (fieldName.equals("tag")) {
         return String.class;

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAlertWorkflowExecution.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowAlertWorkflowExecution.java
@@ -34,18 +34,18 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWorkflowExecution, IDatabases> implements Comparable<WorkflowAlertWorkflowExecution>{
   
-  public static final long serialVersionUID = 9039359899511813425L;
+  public static final long serialVersionUID = 6520835359122253121L;
 
   public static class Tbl extends AbstractTable<WorkflowAlertWorkflowExecution.Attributes, WorkflowAlertWorkflowExecution> {
     public final Column<Long> ID;
     public final Column<Long> WORKFLOW_ALERT_ID;
-    public final Column<Long> WORKFLOW_EXECUTION_ID;
+    public final Column<Integer> WORKFLOW_EXECUTION_ID;
 
     private Tbl(String alias) {
       super("workflow_alert_workflow_executions", alias, WorkflowAlertWorkflowExecution.Attributes.class, WorkflowAlertWorkflowExecution.class);
       this.ID = Column.fromId(alias);
       this.WORKFLOW_ALERT_ID = Column.fromField(alias, _Fields.workflow_alert_id, Long.class);
-      this.WORKFLOW_EXECUTION_ID = Column.fromField(alias, _Fields.workflow_execution_id, Long.class);
+      this.WORKFLOW_EXECUTION_ID = Column.fromField(alias, _Fields.workflow_execution_id, Integer.class);
       Collections.addAll(this.allColumns, ID, WORKFLOW_ALERT_ID, WORKFLOW_EXECUTION_ID);
     }
 
@@ -57,7 +57,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
   public static final Tbl TBL = new Tbl("workflow_alert_workflow_executions");
   public static final Column<Long> ID = TBL.ID;
   public static final Column<Long> WORKFLOW_ALERT_ID = TBL.WORKFLOW_ALERT_ID;
-  public static final Column<Long> WORKFLOW_EXECUTION_ID = TBL.WORKFLOW_EXECUTION_ID;
+  public static final Column<Integer> WORKFLOW_EXECUTION_ID = TBL.WORKFLOW_EXECUTION_ID;
 
   private final Attributes attributes;
 
@@ -80,20 +80,20 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
     return cachedTypedId;
   }
 
-  public WorkflowAlertWorkflowExecution(long id, final long workflow_alert_id, final long workflow_execution_id, IDatabases databases) {
+  public WorkflowAlertWorkflowExecution(long id, final long workflow_alert_id, final int workflow_execution_id, IDatabases databases) {
     super(databases);
     attributes = new Attributes(id, workflow_alert_id, workflow_execution_id);
-    this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+    this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
     this.__assoc_workflow_alert = new BelongsToAssociation<>(databases.getWorkflowDb().workflowAlerts(), getWorkflowAlertId());
   }
 
-  public WorkflowAlertWorkflowExecution(long id, final long workflow_alert_id, final long workflow_execution_id) {
+  public WorkflowAlertWorkflowExecution(long id, final long workflow_alert_id, final int workflow_execution_id) {
     super(null);
     attributes = new Attributes(id, workflow_alert_id, workflow_execution_id);
   }
 
   public static WorkflowAlertWorkflowExecution newDefaultInstance(long id) {
-    return new WorkflowAlertWorkflowExecution(id, 0L, 0L);
+    return new WorkflowAlertWorkflowExecution(id, 0L, 0);
   }
 
   public WorkflowAlertWorkflowExecution(Attributes attributes, IDatabases databases) {
@@ -101,7 +101,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
     this.attributes = attributes;
 
     if (databases != null) {
-      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
       this.__assoc_workflow_alert = new BelongsToAssociation<>(databases.getWorkflowDb().workflowAlerts(), getWorkflowAlertId());
     }
   }
@@ -124,7 +124,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
     attributes = new Attributes(other.getAttributes());
 
     if (databases != null) {
-      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
       this.__assoc_workflow_alert = new BelongsToAssociation<>(databases.getWorkflowDb().workflowAlerts(), getWorkflowAlertId());
     }
   }
@@ -146,11 +146,11 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
     return this;
   }
 
-  public long getWorkflowExecutionId() {
+  public int getWorkflowExecutionId() {
     return attributes.getWorkflowExecutionId();
   }
 
-  public WorkflowAlertWorkflowExecution setWorkflowExecutionId(long newval) {
+  public WorkflowAlertWorkflowExecution setWorkflowExecutionId(int newval) {
     attributes.setWorkflowExecutionId(newval);
     if(__assoc_workflow_execution != null){
       this.__assoc_workflow_execution.setOwnerId(newval);
@@ -165,7 +165,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
         setWorkflowAlertId((Long)value);
         break;
       case workflow_execution_id:
-        setWorkflowExecutionId((Long)value);
+        setWorkflowExecutionId((Integer)value);
         break;
       default:
         throw new IllegalStateException("Invalid field: " + field);
@@ -178,7 +178,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
       return;
     }
     if (fieldName.equals("workflow_execution_id")) {
-      setWorkflowExecutionId((Long)  value);
+      setWorkflowExecutionId((Integer)  value);
       return;
     }
     throw new IllegalStateException("Invalid field: " + fieldName);
@@ -189,7 +189,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
       case workflow_alert_id:
         return long.class;
       case workflow_execution_id:
-        return long.class;
+        return int.class;
       default:
         throw new IllegalStateException("Invalid field: " + field);
     }    
@@ -200,7 +200,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
       return long.class;
     }
     if (fieldName.equals("workflow_execution_id")) {
-      return long.class;
+      return int.class;
     }
     throw new IllegalStateException("Invalid field name: " + fieldName);
   }
@@ -284,7 +284,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
   public WorkflowExecution createWorkflowExecution(final String name, final int status) throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create(name, status);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -293,7 +293,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
   public WorkflowExecution createWorkflowExecution(final Integer app_type, final String name, final String scope_identifier, final int status, final Long start_time, final Long end_time, final Integer application_id, final String pool_override) throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create(app_type, name, scope_identifier, status, start_time, end_time, application_id, pool_override);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -302,7 +302,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
   public WorkflowExecution createWorkflowExecution() throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create("", 0);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -347,30 +347,30 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 5840558989709925536L;
+    public static final long serialVersionUID = 628989512918719487L;
 
     // Fields
     private long __workflow_alert_id;
-    private long __workflow_execution_id;
+    private int __workflow_execution_id;
 
     public Attributes(long id) {
       super(id);
     }
 
-    public Attributes(long id, final long workflow_alert_id, final long workflow_execution_id) {
+    public Attributes(long id, final long workflow_alert_id, final int workflow_execution_id) {
       super(id);
       this.__workflow_alert_id = workflow_alert_id;
       this.__workflow_execution_id = workflow_execution_id;
     }
 
     public static Attributes newDefaultInstance(long id) {
-      return new Attributes(id, 0L, 0L);
+      return new Attributes(id, 0L, 0);
     }
 
     public Attributes(long id, Map<Enum, Object> fieldsMap) {
       super(id);
       long workflow_alert_id = (Long)fieldsMap.get(WorkflowAlertWorkflowExecution._Fields.workflow_alert_id);
-      long workflow_execution_id = (Long)fieldsMap.get(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id);
+      int workflow_execution_id = (Integer)fieldsMap.get(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id);
       this.__workflow_alert_id = workflow_alert_id;
       this.__workflow_execution_id = workflow_execution_id;
     }
@@ -391,11 +391,11 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
       return this;
     }
 
-    public long getWorkflowExecutionId() {
+    public int getWorkflowExecutionId() {
       return __workflow_execution_id;
     }
 
-    public Attributes setWorkflowExecutionId(long newval) {
+    public Attributes setWorkflowExecutionId(int newval) {
       this.__workflow_execution_id = newval;
       cachedHashCode = 0;
       return this;
@@ -407,7 +407,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
           setWorkflowAlertId((Long)value);
           break;
         case workflow_execution_id:
-          setWorkflowExecutionId((Long)value);
+          setWorkflowExecutionId((Integer)value);
           break;
         default:
           throw new IllegalStateException("Invalid field: " + field);
@@ -420,7 +420,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
         return;
       }
       if (fieldName.equals("workflow_execution_id")) {
-        setWorkflowExecutionId((Long)value);
+        setWorkflowExecutionId((Integer)value);
         return;
       }
       throw new IllegalStateException("Invalid field: " + fieldName);
@@ -431,7 +431,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
         case workflow_alert_id:
           return long.class;
         case workflow_execution_id:
-          return long.class;
+          return int.class;
         default:
           throw new IllegalStateException("Invalid field: " + field);
       }    
@@ -442,7 +442,7 @@ public class WorkflowAlertWorkflowExecution extends ModelWithId<WorkflowAlertWor
         return long.class;
       }
       if (fieldName.equals("workflow_execution_id")) {
-        return long.class;
+        return int.class;
       }
       throw new IllegalStateException("Invalid field name: " + fieldName);
     }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowExecutionConfiguredNotification.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/models/WorkflowExecutionConfiguredNotification.java
@@ -34,17 +34,17 @@ import com.rapleaf.jack.util.JackUtility;
 
 public class WorkflowExecutionConfiguredNotification extends ModelWithId<WorkflowExecutionConfiguredNotification, IDatabases> implements Comparable<WorkflowExecutionConfiguredNotification>{
   
-  public static final long serialVersionUID = 2403628880853412806L;
+  public static final long serialVersionUID = -5286097310555889919L;
 
   public static class Tbl extends AbstractTable<WorkflowExecutionConfiguredNotification.Attributes, WorkflowExecutionConfiguredNotification> {
     public final Column<Long> ID;
-    public final Column<Long> WORKFLOW_EXECUTION_ID;
+    public final Column<Integer> WORKFLOW_EXECUTION_ID;
     public final Column<Long> CONFIGURED_NOTIFICATION_ID;
 
     private Tbl(String alias) {
       super("workflow_execution_configured_notifications", alias, WorkflowExecutionConfiguredNotification.Attributes.class, WorkflowExecutionConfiguredNotification.class);
       this.ID = Column.fromId(alias);
-      this.WORKFLOW_EXECUTION_ID = Column.fromField(alias, _Fields.workflow_execution_id, Long.class);
+      this.WORKFLOW_EXECUTION_ID = Column.fromField(alias, _Fields.workflow_execution_id, Integer.class);
       this.CONFIGURED_NOTIFICATION_ID = Column.fromField(alias, _Fields.configured_notification_id, Long.class);
       Collections.addAll(this.allColumns, ID, WORKFLOW_EXECUTION_ID, CONFIGURED_NOTIFICATION_ID);
     }
@@ -56,7 +56,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
 
   public static final Tbl TBL = new Tbl("workflow_execution_configured_notifications");
   public static final Column<Long> ID = TBL.ID;
-  public static final Column<Long> WORKFLOW_EXECUTION_ID = TBL.WORKFLOW_EXECUTION_ID;
+  public static final Column<Integer> WORKFLOW_EXECUTION_ID = TBL.WORKFLOW_EXECUTION_ID;
   public static final Column<Long> CONFIGURED_NOTIFICATION_ID = TBL.CONFIGURED_NOTIFICATION_ID;
 
   private final Attributes attributes;
@@ -80,20 +80,20 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
     return cachedTypedId;
   }
 
-  public WorkflowExecutionConfiguredNotification(long id, final long workflow_execution_id, final long configured_notification_id, IDatabases databases) {
+  public WorkflowExecutionConfiguredNotification(long id, final int workflow_execution_id, final long configured_notification_id, IDatabases databases) {
     super(databases);
     attributes = new Attributes(id, workflow_execution_id, configured_notification_id);
     this.__assoc_configured_notification = new BelongsToAssociation<>(databases.getWorkflowDb().configuredNotifications(), getConfiguredNotificationId());
-    this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+    this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
   }
 
-  public WorkflowExecutionConfiguredNotification(long id, final long workflow_execution_id, final long configured_notification_id) {
+  public WorkflowExecutionConfiguredNotification(long id, final int workflow_execution_id, final long configured_notification_id) {
     super(null);
     attributes = new Attributes(id, workflow_execution_id, configured_notification_id);
   }
 
   public static WorkflowExecutionConfiguredNotification newDefaultInstance(long id) {
-    return new WorkflowExecutionConfiguredNotification(id, 0L, 0L);
+    return new WorkflowExecutionConfiguredNotification(id, 0, 0L);
   }
 
   public WorkflowExecutionConfiguredNotification(Attributes attributes, IDatabases databases) {
@@ -102,7 +102,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
 
     if (databases != null) {
       this.__assoc_configured_notification = new BelongsToAssociation<>(databases.getWorkflowDb().configuredNotifications(), getConfiguredNotificationId());
-      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
     }
   }
 
@@ -125,7 +125,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
 
     if (databases != null) {
       this.__assoc_configured_notification = new BelongsToAssociation<>(databases.getWorkflowDb().configuredNotifications(), getConfiguredNotificationId());
-      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), getWorkflowExecutionId());
+      this.__assoc_workflow_execution = new BelongsToAssociation<>(databases.getWorkflowDb().workflowExecutions(), (long) getWorkflowExecutionId());
     }
   }
 
@@ -133,11 +133,11 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
     return attributes;
   }
 
-  public long getWorkflowExecutionId() {
+  public int getWorkflowExecutionId() {
     return attributes.getWorkflowExecutionId();
   }
 
-  public WorkflowExecutionConfiguredNotification setWorkflowExecutionId(long newval) {
+  public WorkflowExecutionConfiguredNotification setWorkflowExecutionId(int newval) {
     attributes.setWorkflowExecutionId(newval);
     if(__assoc_workflow_execution != null){
       this.__assoc_workflow_execution.setOwnerId(newval);
@@ -162,7 +162,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   public void setField(_Fields field, Object value) {
     switch (field) {
       case workflow_execution_id:
-        setWorkflowExecutionId((Long)value);
+        setWorkflowExecutionId((Integer)value);
         break;
       case configured_notification_id:
         setConfiguredNotificationId((Long)value);
@@ -174,7 +174,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   
   public void setField(String fieldName, Object value) {
     if (fieldName.equals("workflow_execution_id")) {
-      setWorkflowExecutionId((Long)  value);
+      setWorkflowExecutionId((Integer)  value);
       return;
     }
     if (fieldName.equals("configured_notification_id")) {
@@ -187,7 +187,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   public static Class getFieldType(_Fields field) {
     switch (field) {
       case workflow_execution_id:
-        return long.class;
+        return int.class;
       case configured_notification_id:
         return long.class;
       default:
@@ -197,7 +197,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
 
   public static Class getFieldType(String fieldName) {    
     if (fieldName.equals("workflow_execution_id")) {
-      return long.class;
+      return int.class;
     }
     if (fieldName.equals("configured_notification_id")) {
       return long.class;
@@ -311,7 +311,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   public WorkflowExecution createWorkflowExecution(final String name, final int status) throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create(name, status);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -320,7 +320,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   public WorkflowExecution createWorkflowExecution(final Integer app_type, final String name, final String scope_identifier, final int status, final Long start_time, final Long end_time, final Integer application_id, final String pool_override) throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create(app_type, name, scope_identifier, status, start_time, end_time, application_id, pool_override);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -329,7 +329,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   public WorkflowExecution createWorkflowExecution() throws IOException {
  
     WorkflowExecution newWorkflowExecution = databases.getWorkflowDb().workflowExecutions().create("", 0);
-    setWorkflowExecutionId(newWorkflowExecution.getId());
+    setWorkflowExecutionId(JackUtility.safeLongToInt(newWorkflowExecution.getId()));
     save();
     __assoc_workflow_execution.clearCache();
     return newWorkflowExecution;
@@ -356,29 +356,29 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
   
   public static class Attributes extends AttributesWithId {
     
-    public static final long serialVersionUID = 5526705265741082250L;
+    public static final long serialVersionUID = -5746196685832151069L;
 
     // Fields
-    private long __workflow_execution_id;
+    private int __workflow_execution_id;
     private long __configured_notification_id;
 
     public Attributes(long id) {
       super(id);
     }
 
-    public Attributes(long id, final long workflow_execution_id, final long configured_notification_id) {
+    public Attributes(long id, final int workflow_execution_id, final long configured_notification_id) {
       super(id);
       this.__workflow_execution_id = workflow_execution_id;
       this.__configured_notification_id = configured_notification_id;
     }
 
     public static Attributes newDefaultInstance(long id) {
-      return new Attributes(id, 0L, 0L);
+      return new Attributes(id, 0, 0L);
     }
 
     public Attributes(long id, Map<Enum, Object> fieldsMap) {
       super(id);
-      long workflow_execution_id = (Long)fieldsMap.get(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id);
+      int workflow_execution_id = (Integer)fieldsMap.get(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id);
       long configured_notification_id = (Long)fieldsMap.get(WorkflowExecutionConfiguredNotification._Fields.configured_notification_id);
       this.__workflow_execution_id = workflow_execution_id;
       this.__configured_notification_id = configured_notification_id;
@@ -390,11 +390,11 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
       this.__configured_notification_id = other.getConfiguredNotificationId();
     }
 
-    public long getWorkflowExecutionId() {
+    public int getWorkflowExecutionId() {
       return __workflow_execution_id;
     }
 
-    public Attributes setWorkflowExecutionId(long newval) {
+    public Attributes setWorkflowExecutionId(int newval) {
       this.__workflow_execution_id = newval;
       cachedHashCode = 0;
       return this;
@@ -413,7 +413,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
     public void setField(_Fields field, Object value) {
       switch (field) {
         case workflow_execution_id:
-          setWorkflowExecutionId((Long)value);
+          setWorkflowExecutionId((Integer)value);
           break;
         case configured_notification_id:
           setConfiguredNotificationId((Long)value);
@@ -425,7 +425,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
 
     public void setField(String fieldName, Object value) {
       if (fieldName.equals("workflow_execution_id")) {
-        setWorkflowExecutionId((Long)value);
+        setWorkflowExecutionId((Integer)value);
         return;
       }
       if (fieldName.equals("configured_notification_id")) {
@@ -438,7 +438,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
     public static Class getFieldType(_Fields field) {
       switch (field) {
         case workflow_execution_id:
-          return long.class;
+          return int.class;
         case configured_notification_id:
           return long.class;
         default:
@@ -448,7 +448,7 @@ public class WorkflowExecutionConfiguredNotification extends ModelWithId<Workflo
 
     public static Class getFieldType(String fieldName) {    
       if (fieldName.equals("workflow_execution_id")) {
-        return long.class;
+        return int.class;
       }
       if (fieldName.equals("configured_notification_id")) {
         return long.class;

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/ExecutionTagDeleteBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/ExecutionTagDeleteBuilder.java
@@ -31,13 +31,13 @@ public class ExecutionTagDeleteBuilder extends AbstractDeleteBuilder<ExecutionTa
     return this;
   }
 
-  public ExecutionTagDeleteBuilder workflowExecutionId(Long value) {
-    addWhereConstraint(new WhereConstraint<Long>(ExecutionTag._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
+  public ExecutionTagDeleteBuilder workflowExecutionId(Integer value) {
+    addWhereConstraint(new WhereConstraint<Integer>(ExecutionTag._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
     return this;
   }
 
-  public ExecutionTagDeleteBuilder whereWorkflowExecutionId(IWhereOperator<Long> operator) {
-    addWhereConstraint(new WhereConstraint<Long>(ExecutionTag._Fields.workflow_execution_id, operator));
+  public ExecutionTagDeleteBuilder whereWorkflowExecutionId(IWhereOperator<Integer> operator) {
+    addWhereConstraint(new WhereConstraint<Integer>(ExecutionTag._Fields.workflow_execution_id, operator));
     return this;
   }
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/ExecutionTagQueryBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/ExecutionTagQueryBuilder.java
@@ -88,12 +88,12 @@ public class ExecutionTagQueryBuilder extends AbstractQueryBuilder<ExecutionTag>
     return this;
   }
 
-  public ExecutionTagQueryBuilder workflowExecutionId(Long value) {
+  public ExecutionTagQueryBuilder workflowExecutionId(Integer value) {
     addWhereConstraint(new WhereConstraint<>(ExecutionTag._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
     return this;
   }
 
-  public ExecutionTagQueryBuilder whereWorkflowExecutionId(IWhereOperator<Long> operator) {
+  public ExecutionTagQueryBuilder whereWorkflowExecutionId(IWhereOperator<Integer> operator) {
     addWhereConstraint(new WhereConstraint<>(ExecutionTag._Fields.workflow_execution_id, operator));
     return this;
   }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAlertWorkflowExecutionDeleteBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAlertWorkflowExecutionDeleteBuilder.java
@@ -41,13 +41,13 @@ public class WorkflowAlertWorkflowExecutionDeleteBuilder extends AbstractDeleteB
     return this;
   }
 
-  public WorkflowAlertWorkflowExecutionDeleteBuilder workflowExecutionId(Long value) {
-    addWhereConstraint(new WhereConstraint<Long>(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
+  public WorkflowAlertWorkflowExecutionDeleteBuilder workflowExecutionId(Integer value) {
+    addWhereConstraint(new WhereConstraint<Integer>(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
     return this;
   }
 
-  public WorkflowAlertWorkflowExecutionDeleteBuilder whereWorkflowExecutionId(IWhereOperator<Long> operator) {
-    addWhereConstraint(new WhereConstraint<Long>(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, operator));
+  public WorkflowAlertWorkflowExecutionDeleteBuilder whereWorkflowExecutionId(IWhereOperator<Integer> operator) {
+    addWhereConstraint(new WhereConstraint<Integer>(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, operator));
     return this;
   }
 }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAlertWorkflowExecutionQueryBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowAlertWorkflowExecutionQueryBuilder.java
@@ -108,12 +108,12 @@ public class WorkflowAlertWorkflowExecutionQueryBuilder extends AbstractQueryBui
     return this;
   }
 
-  public WorkflowAlertWorkflowExecutionQueryBuilder workflowExecutionId(Long value) {
+  public WorkflowAlertWorkflowExecutionQueryBuilder workflowExecutionId(Integer value) {
     addWhereConstraint(new WhereConstraint<>(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
     return this;
   }
 
-  public WorkflowAlertWorkflowExecutionQueryBuilder whereWorkflowExecutionId(IWhereOperator<Long> operator) {
+  public WorkflowAlertWorkflowExecutionQueryBuilder whereWorkflowExecutionId(IWhereOperator<Integer> operator) {
     addWhereConstraint(new WhereConstraint<>(WorkflowAlertWorkflowExecution._Fields.workflow_execution_id, operator));
     return this;
   }

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowExecutionConfiguredNotificationDeleteBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowExecutionConfiguredNotificationDeleteBuilder.java
@@ -31,13 +31,13 @@ public class WorkflowExecutionConfiguredNotificationDeleteBuilder extends Abstra
     return this;
   }
 
-  public WorkflowExecutionConfiguredNotificationDeleteBuilder workflowExecutionId(Long value) {
-    addWhereConstraint(new WhereConstraint<Long>(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
+  public WorkflowExecutionConfiguredNotificationDeleteBuilder workflowExecutionId(Integer value) {
+    addWhereConstraint(new WhereConstraint<Integer>(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
     return this;
   }
 
-  public WorkflowExecutionConfiguredNotificationDeleteBuilder whereWorkflowExecutionId(IWhereOperator<Long> operator) {
-    addWhereConstraint(new WhereConstraint<Long>(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, operator));
+  public WorkflowExecutionConfiguredNotificationDeleteBuilder whereWorkflowExecutionId(IWhereOperator<Integer> operator) {
+    addWhereConstraint(new WhereConstraint<Integer>(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, operator));
     return this;
   }
 

--- a/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowExecutionConfiguredNotificationQueryBuilder.java
+++ b/workflow_db/src/main/java/com/liveramp/databases/workflow_db/query/WorkflowExecutionConfiguredNotificationQueryBuilder.java
@@ -88,12 +88,12 @@ public class WorkflowExecutionConfiguredNotificationQueryBuilder extends Abstrac
     return this;
   }
 
-  public WorkflowExecutionConfiguredNotificationQueryBuilder workflowExecutionId(Long value) {
+  public WorkflowExecutionConfiguredNotificationQueryBuilder workflowExecutionId(Integer value) {
     addWhereConstraint(new WhereConstraint<>(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, JackMatchers.equalTo(value)));
     return this;
   }
 
-  public WorkflowExecutionConfiguredNotificationQueryBuilder whereWorkflowExecutionId(IWhereOperator<Long> operator) {
+  public WorkflowExecutionConfiguredNotificationQueryBuilder whereWorkflowExecutionId(IWhereOperator<Integer> operator) {
     addWhereConstraint(new WhereConstraint<>(WorkflowExecutionConfiguredNotification._Fields.workflow_execution_id, operator));
     return this;
   }

--- a/workflow_hadoop/src/test/java/com/liveramp/workflow/WorkflowRunnerIT.java
+++ b/workflow_hadoop/src/test/java/com/liveramp/workflow/WorkflowRunnerIT.java
@@ -265,7 +265,7 @@ public class WorkflowRunnerIT extends WorkflowTestCase {
     );
 
     ExecutionController.addConfiguredNotifications(workflowDb,
-        wr.getPersistence().getExecutionId(),
+        Math.toIntExact(wr.getPersistence().getExecutionId()),
         "ben@gmail.com",
         WorkflowNotificationLevel.ERROR
     );

--- a/workflow_monitor/src/main/java/com/liveramp/workflow_monitor/alerts/execution/alert/AlertMessage.java
+++ b/workflow_monitor/src/main/java/com/liveramp/workflow_monitor/alerts/execution/alert/AlertMessage.java
@@ -48,7 +48,7 @@ public class AlertMessage {
         alertClass);
   }
 
-  private static boolean hasAlertedExecution(IWorkflowDb wfDb, long executionId, String alertClass) throws IOException {
+  private static boolean hasAlertedExecution(IWorkflowDb wfDb, int executionId, String alertClass) throws IOException {
     return existAlerts(wfDb.createQuery()
             .from(WorkflowAlertWorkflowExecution.TBL)
             .where(WorkflowAlertWorkflowExecution.WORKFLOW_EXECUTION_ID.equalTo(executionId))
@@ -66,9 +66,9 @@ public class AlertMessage {
   public static AlertMessage createAlertMessage(String classname, String message, WorkflowRunnerNotification notification,
                                                 WorkflowExecution execution, IDatabases db) throws IOException {
     IWorkflowDb wfDb = db.getWorkflowDb();
-    if (!hasAlertedExecution(wfDb, execution.getId(), classname)) {
+    if (!hasAlertedExecution(wfDb, execution.getIntId(), classname)) {
       WorkflowAlert wa = wfDb.workflowAlerts().create(classname, message);
-      wfDb.workflowAlertWorkflowExecutions().create(wa.getId(), execution.getId());
+      wfDb.workflowAlertWorkflowExecutions().create(wa.getId(), execution.getIntId());
       return new AlertMessage(classname, message, notification);
     } else {
       LOG.debug("Not re-notifying about execution " + execution.getId() + " alert gen " + classname);

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/CoreWorkflowDbPersistenceFactory.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/CoreWorkflowDbPersistenceFactory.java
@@ -22,7 +22,6 @@ import com.liveramp.cascading_ext.resource.ResourceDeclarerFactory;
 import com.liveramp.databases.workflow_db.DatabasesImpl;
 import com.liveramp.databases.workflow_db.IWorkflowDb;
 import com.liveramp.databases.workflow_db.models.Application;
-import com.liveramp.databases.workflow_db.models.ApplicationConfiguredNotification;
 import com.liveramp.databases.workflow_db.models.BackgroundAttemptInfo;
 import com.liveramp.databases.workflow_db.models.ConfiguredNotification;
 import com.liveramp.databases.workflow_db.models.StepAttempt;
@@ -304,17 +303,17 @@ public abstract class CoreWorkflowDbPersistenceFactory<S extends IStep,
       long hb = System.currentTimeMillis();
       attempt.setLastHeartbeat(hb)
           .setLastHeartbeatEpoch(hb);
-    }else{
+    } else {
       attempt.setLastHeartbeat(0L)
           .setLastHeartbeatEpoch(0L);
     }
 
     attempt.save();
 
-    if(!manager.isLive()) {
+    if (!manager.isLive()) {
       BackgroundAttemptInfo backgroundInfo = workflowDb.backgroundAttemptInfos().create(attempt.getId());
 
-      if(resourceFactory != null){
+      if (resourceFactory != null) {
         backgroundInfo.setResourceManagerFactory(resourceFactory.getName());
         //  this is dumb, but I don't want to clean up Resource right now to fix it.
         backgroundInfo.setResourceManagerVersionClass(InitializedDbPersistence.class.getName());
@@ -415,7 +414,7 @@ public abstract class CoreWorkflowDbPersistenceFactory<S extends IStep,
       }
 
       for (WorkflowTag tag : tags) {
-        workflowDb.executionTags().create(ex.getId(), tag.getKey(), tag.getVal());
+        workflowDb.executionTags().create(ex.getIntId(), tag.getKey(), tag.getVal());
       }
 
       ex.save();

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/DbPersistence.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/DbPersistence.java
@@ -748,7 +748,7 @@ public class DbPersistence implements WorkflowStatePersistence {
       ));
 
       allNotifications.addAll(WorkflowQueries.getExecutionNotifications(conn,
-          getExecutionId(),
+          Math.toIntExact(getExecutionId()),
           notification
       ));
 

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/WorkflowQueries.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/WorkflowQueries.java
@@ -606,19 +606,19 @@ public class WorkflowQueries {
     );
   }
 
-  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Long executionId) throws IOException {
+  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Integer executionId) throws IOException {
     return getExecutionNotifications(db, executionId, null, null);
   }
 
-  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Long executionId, String email) throws IOException {
+  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Integer executionId, String email) throws IOException {
     return getExecutionNotifications(db, executionId, null, email);
   }
 
-  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Long executionId, WorkflowRunnerNotification type) throws IOException {
+  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Integer executionId, WorkflowRunnerNotification type) throws IOException {
     return getExecutionNotifications(db, executionId, type, null);
   }
 
-  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Long executionId, WorkflowRunnerNotification type, String email) throws IOException {
+  public static List<ConfiguredNotification.Attributes> getExecutionNotifications(IWorkflowDb db, Integer executionId, WorkflowRunnerNotification type, String email) throws IOException {
     return getNotifications(db.createQuery().from(WorkflowExecutionConfiguredNotification.TBL)
             .where(WorkflowExecutionConfiguredNotification.WORKFLOW_EXECUTION_ID.equalTo(executionId))
             .innerJoin(ConfiguredNotification.TBL)

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/controller/ExecutionController.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/controller/ExecutionController.java
@@ -36,30 +36,30 @@ public class ExecutionController {
 
   }
 
-  public static void addConfiguredNotifications(IWorkflowDb workflowDb, Long workflowId, String email, Set<WorkflowRunnerNotification> notifications) throws IOException {
+  public static void addConfiguredNotifications(IWorkflowDb workflowDb, Integer workflowId, String email, Set<WorkflowRunnerNotification> notifications) throws IOException {
     WorkflowExecution execution = workflowDb.workflowExecutions().find(workflowId);
 
     Set<WorkflowRunnerNotification> existing = Sets.newHashSet();
-    for (ConfiguredNotification.Attributes attributes : WorkflowQueries.getExecutionNotifications(workflowDb, execution.getId(), email)) {
+    for (ConfiguredNotification.Attributes attributes : WorkflowQueries.getExecutionNotifications(workflowDb, execution.getIntId(), email)) {
       existing.add(WorkflowRunnerNotification.findByValue(attributes.getWorkflowRunnerNotification()));
     }
 
     for (WorkflowRunnerNotification notification : notifications) {
       if (!existing.contains(notification)) {
         ConfiguredNotification configured = workflowDb.configuredNotifications().create(notification.ordinal(), email, false);
-        workflowDb.workflowExecutionConfiguredNotifications().create(execution.getId(), configured.getId());
+        workflowDb.workflowExecutionConfiguredNotifications().create(execution.getIntId(), configured.getId());
       }
     }
 
   }
 
-  public static void removeConfiguredNotifications(IWorkflowDb workflowDb, Long workflowId, String email) throws IOException {
+  public static void removeConfiguredNotifications(IWorkflowDb workflowDb, Integer workflowId, String email) throws IOException {
     removeConfiguredNotifications(workflowDb, workflowId, email, EnumSet.allOf(WorkflowRunnerNotification.class));
   }
 
-  public static void removeConfiguredNotifications(IWorkflowDb workflowDb, Long workflowId, String email, Set<WorkflowRunnerNotification> notificaions) throws IOException {
+  public static void removeConfiguredNotifications(IWorkflowDb workflowDb, Integer workflowId, String email, Set<WorkflowRunnerNotification> notificaions) throws IOException {
     WorkflowExecution execution = workflowDb.workflowExecutions().find(workflowId);
-    long id = execution.getId();
+    int id = execution.getIntId();
 
     for (ConfiguredNotification.Attributes attributes : WorkflowQueries.getExecutionNotifications(workflowDb, id, email)) {
       if (notificaions.contains(WorkflowRunnerNotification.findByValue(attributes.getWorkflowRunnerNotification()))) {

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/json/WorkflowJSON.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/json/WorkflowJSON.java
@@ -259,7 +259,7 @@ public class WorkflowJSON {
         if (details) {
 
           JSONArray notifications = new JSONArray();
-          for (ConfiguredNotification.Attributes attributes : WorkflowQueries.getExecutionNotifications(workflowDb, execution.getId())) {
+          for (ConfiguredNotification.Attributes attributes : WorkflowQueries.getExecutionNotifications(workflowDb, execution.getIntId())) {
             notifications.put(toJSON(attributes));
           }
 

--- a/workflow_state/src/test/java/com/liveramp/workflow_db_state/controller/ExecutionControllerIT.java
+++ b/workflow_state/src/test/java/com/liveramp/workflow_db_state/controller/ExecutionControllerIT.java
@@ -26,7 +26,7 @@ public class ExecutionControllerIT extends WorkflowDbStateTestCase {
 
     IWorkflowDb workflowDb = new DatabasesImpl().getWorkflowDb();
     WorkflowExecution test = workflowDb.workflowExecutions().create("test", WorkflowExecutionStatus.INCOMPLETE.ordinal());
-    long exId = test.getId();
+    int exId = test.getIntId();
 
     addConfiguredNotifications(workflowDb, exId, "ben@gmail.com",
         Sets.newHashSet(WorkflowRunnerNotification.DIED_UNCLEAN, WorkflowRunnerNotification.FAILURE)

--- a/workflow_ui/src/main/java/com/liveramp/workflow_ui/servlet/command/NotificationConfigurationServlet.java
+++ b/workflow_ui/src/main/java/com/liveramp/workflow_ui/servlet/command/NotificationConfigurationServlet.java
@@ -56,7 +56,7 @@ public class NotificationConfigurationServlet extends HttpServlet {
         if (contains(APP_NAME, req)) {
           ApplicationController.addConfiguredNotifications(worflowDb, get(APP_NAME, req), email, notifications);
         } else if (contains(EX_ID, req)) {
-          ExecutionController.addConfiguredNotifications(worflowDb, Long.parseLong(get(EX_ID, req)), email, notifications);
+          ExecutionController.addConfiguredNotifications(worflowDb, Integer.parseInt(get(EX_ID, req)), email, notifications);
         } else {
           throw new IllegalArgumentException();
         }
@@ -65,7 +65,7 @@ public class NotificationConfigurationServlet extends HttpServlet {
         if (contains(APP_NAME, req)) {
           ApplicationController.removeConfiguredNotifications(worflowDb, get(APP_NAME, req), email);
         } else if (contains(EX_ID, req)) {
-          ExecutionController.removeConfiguredNotifications(worflowDb, Long.parseLong(get(EX_ID, req)), email);
+          ExecutionController.removeConfiguredNotifications(worflowDb, Integer.parseInt(get(EX_ID, req)), email);
         } else {
           throw new IllegalArgumentException();
         }


### PR DESCRIPTION
The end goal is to make sweeping worklow db easy. If the right foreign key constraints are added, sweeping the entire database will be as simple as deleting all workflow_executions. I'm splitting the migrations up so each one runs in a reasonable amount of time. I've already tested this one on a back-up database and I expect this will take less than 10 minutes

TODO:
 - workflow_attempt_id
 - step_attempt_id
 - mapreduce_job_id (except counters),
 - mapreduce_counters