### PR TITLE
Fix workflow cancellation when there is no auth

### DIFF
--- a/workflow_ui/src/main/java/com/liveramp/workflow_ui/security/SecurityConfig.java
+++ b/workflow_ui/src/main/java/com/liveramp/workflow_ui/security/SecurityConfig.java
@@ -40,7 +40,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     if (getAuthMethod().equals("none")) {
       http.authorizeRequests()
           .antMatchers("/*")
-          .permitAll();
+          .permitAll()
+          .and()
+          .csrf()
+          .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
     } else {
       http
           .authorizeRequests()


### PR DESCRIPTION
Someone noticed that they weren't able to cancel workflows after we turned off auth. @aharelick noticed that the request returned `403 Could not verify the provided CRSF token because your session was not found` in the browser. I blindly copy and pasted the parts of the code with `crsf` in the name and it seems to work
