### PR TITLE
Increase heartbeat timeout from 15 seconds to 1 minutes

### DIFF
--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/DbPersistence.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/DbPersistence.java
@@ -60,7 +60,7 @@ import com.rapleaf.jack.queries.where_operators.EqualTo;
 public class DbPersistence implements WorkflowStatePersistence {
   private static final Logger LOG = LoggerFactory.getLogger(DbPersistence.class);
 
-  public static final long HEARTBEAT_INTERVAL = 5 * 60 * 1000; //  5m
+  public static final long HEARTBEAT_INTERVAL = 1 * 60 * 1000; //  1m
   public static final int NUM_HEARTBEAT_TIMEOUTS = 4;  //  if an attempt misses 4 heartbeats, assume it is dead
 
   private final MailBuffer testMailBuffer;

--- a/workflow_state/src/main/java/com/liveramp/workflow_db_state/DbPersistence.java
+++ b/workflow_state/src/main/java/com/liveramp/workflow_db_state/DbPersistence.java
@@ -60,7 +60,7 @@ import com.rapleaf.jack.queries.where_operators.EqualTo;
 public class DbPersistence implements WorkflowStatePersistence {
   private static final Logger LOG = LoggerFactory.getLogger(DbPersistence.class);
 
-  public static final long HEARTBEAT_INTERVAL = 15 * 1000; //  15s
+  public static final long HEARTBEAT_INTERVAL = 5 * 60 * 1000; //  5m
   public static final int NUM_HEARTBEAT_TIMEOUTS = 4;  //  if an attempt misses 4 heartbeats, assume it is dead
 
   private final MailBuffer testMailBuffer;


### PR DESCRIPTION
We're processing over 400 queries per second at peak times now. About half of which are updates. Increasing the heartbeat interval should cut that dramatically