### PR TITLE
Stop displaying counters in the UI

### DIFF
--- a/workflow_ui/src/main/resources/com/liveramp/workflow_ui/www/workflow.html
+++ b/workflow_ui/src/main/resources/com/liveramp/workflow_ui/www/workflow.html
@@ -671,20 +671,6 @@
                         '</tbody>'
                     ));
 
-            var counterTbody = $('<tbody></tbody>');
-
-            _.sortBy(job.counters, function (e) {
-              return e.group + e.name
-            }).forEach(function (e) {
-              counterTbody.append($(
-                  '<tr>' +
-                  '<td>' + e.group + '</td>' +
-                  '<td>' + e.name + '</td>' +
-                  '<td>' + e.value + '</td>' +
-                  '</tr>'
-              ));
-            });
-
             var failureTbody = $('<tbody></tbody>');
 
             job.task_exceptions.forEach(function (e) {
@@ -700,12 +686,7 @@
                 .addClass(e.status)
                 .append(failureTbody);
 
-            var counterTable = $('<table class="table workflow_step_row"></table>')
-                .addClass(e.status)
-                .append(counterTbody);
-
             div.append(tableDetails)
-                .append(counterTable)
                 .append(exceptionTable);
           }
         }


### PR DESCRIPTION
Users can still click through the job history server if they want look
at the counters for a specific job. If people complain loudly, then maybe
we could query the job history server for the counters whenever someone
vists a page.

This is part of a longer-term plan to stop persisting counters in workflow
DB so we have fewer inserts overall. We think this will make it possible
for us to migrate workflow DB off of custom MySQL setup we have and onto
CloudSQL.