### PR TITLE
upgrade cascading_ext dependency

### DIFF
--- a/workflow_hadoop/pom.xml
+++ b/workflow_hadoop/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.liveramp</groupId>
       <artifactId>cascading_ext</artifactId>
-      <version>1.7</version>
+      <version>1.8-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I'm specifically interested in pulling in this change: https://github.com/LiveRamp/cascading_ext/pull/90

Internally found this in this thread: https://liveramp.slack.com/archives/C3TUTRT35/p1584591886103600?thread_ts=1584570734.091100&cid=C3TUTRT35